### PR TITLE
Add about page with attorney bio and CTA

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>About | VI Bankruptcy</title>
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
+
+  <style>
+    :root {
+      --vi-1: #1B3940; /* Deep Teal */
+      --vi-2: #132326; /* Midnight */
+      --vi-3: #59453E; /* Brown‑Gray */
+      --vi-4: #A68D85; /* Taupe */
+      --vi-5: #D9C6BF; /* Shell */
+      --vi-gold: #BD9E07; /* accent line */
+      --vi-nav: #1C1F19; /* navigation bar */
+      --vi-gray: #F4F4F4; /* utility gray */
+    }
+
+    body {
+      margin: 0;
+      font-family: "Open Sans", Arial, sans-serif;
+      color: var(--vi-2);
+      line-height: 1.6;
+      background: #fff;
+    }
+
+    /* Background helpers */
+    .bg-white { background: #fff; color: var(--vi-2); }
+    .bg-gray  { background: var(--vi-gray); color: var(--vi-2); }
+
+    /* Header */
+    .site-header {
+      background: var(--vi-nav);
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.75rem 1.25rem;
+      border-bottom: 1px solid var(--vi-gold);
+    }
+    .site-header nav a {
+      color: #fff;
+      text-decoration: none;
+      margin-left: 1rem;
+      font-weight: 600;
+    }
+    .site-header nav a:hover { text-decoration: underline; }
+    .logo-link img { height: 48px; width: auto; }
+
+    /* Hero */
+    .hero {
+      position: relative;
+      height: 60vh;
+      min-height: 420px;
+      background: url("https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/77a43069-ed54-403f-d367-7b5bd71ef000/public") center/cover no-repeat;
+      display: flex;
+      align-items: center;
+      padding: 0 1.25rem;
+    }
+    .hero h1 {
+      font-family: "Cinzel", serif;
+      font-size: clamp(1.75rem, 4vw + 0.5rem, 3rem);
+      font-weight: 400;
+      color: #C8B27F;
+      margin: 0;
+      text-transform: uppercase;
+      line-height: 1.2;
+    }
+
+    /* Section base */
+    section { padding: 3rem 1.25rem; }
+
+    h2 {
+      font-family: "Merriweather", serif;
+      font-weight: 700;
+      margin-top: 0;
+      font-size: 2rem;
+      color: var(--vi-1);
+      text-align: center;
+    }
+
+    .services {
+      display: grid;
+      gap: 2rem;
+      max-width: 1100px;
+      margin: 0 auto;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+    .service-card {
+      background: #fff;
+      padding: 1.5rem;
+      border-radius: 6px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+      color: var(--vi-2);
+    }
+    .service-card h3 {
+      margin-top: 0;
+      font-family: "Merriweather", serif;
+      font-size: 1.25rem;
+      color: var(--vi-1);
+    }
+
+    .why-list {
+      list-style: none;
+      padding: 0;
+      margin: 0 auto;
+      max-width: 600px;
+      color: var(--vi-2);
+    }
+    .why-list li {
+      margin-bottom: 0.75rem;
+      padding-left: 1.5rem;
+      position: relative;
+    }
+    .why-list li:before {
+      content: "\2713";
+      position: absolute;
+      left: 0;
+      color: var(--vi-gold);
+    }
+
+    /* Testimonials */
+    .testimonials {
+      background: var(--vi-1);
+      color: #fff;
+      padding: 2rem 1.25rem;
+      border-radius: 6px;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+    .testimonials blockquote {
+      margin: 0 0 1rem;
+      font-style: italic;
+    }
+
+    /* CTA */
+    .cta { text-align: center; }
+    .btn {
+      display: inline-block;
+      background: var(--vi-1);
+      color: #fff;
+      padding: 0.75rem 1.5rem;
+      border-radius: 4px;
+      text-decoration: none;
+      font-weight: 600;
+      margin-top: 1rem;
+    }
+
+    /* Contact */
+    .contact-grid {
+      display: grid;
+      gap: 2rem;
+      max-width: 1000px;
+      margin: 0 auto;
+      color: #fff;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+    .contact-grid input,
+    .contact-grid textarea {
+      width: 100%;
+      padding: 0.5rem;
+      margin-top: 0.25rem;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+      font: inherit;
+    }
+
+    footer {
+      background: var(--vi-nav);
+      color: #fff;
+      padding: 2rem 1.25rem;
+      font-size: 0.875rem;
+      text-align: center;
+    }
+
+    /* About page layout */
+    .about-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 2rem;
+      max-width: 1100px;
+      margin: 0 auto;
+    }
+    .about-wrapper img {
+      width: 100%;
+      max-width: 320px;
+      border-radius: 6px;
+    }
+    .about-text { flex: 1; }
+    @media (min-width: 768px) {
+      .about-wrapper { flex-direction: row; }
+    }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <a href="/" class="logo-link">
+      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+    </a>
+    <nav>
+      <a href="index.html#services">Services</a>
+      <a href="index.html#why">Why Us</a>
+      <a href="index.html#testimonials">Testimonials</a>
+      <a href="index.html#contact">Contact</a>
+    </nav>
+  </header>
+
+  <section class="bg-white" id="about">
+    <h1 style="text-align:center;">About Us</h1>
+    <div class="about-wrapper">
+      <img src="https://via.placeholder.com/320x400" alt="Robert A. Pohl - Bankruptcy Attorney" />
+      <div class="about-text">
+        <h2 style="text-align:left;">Robert A. Pohl – Bankruptcy Attorney</h2>
+        <p>Robert A. Pohl is a seasoned bankruptcy attorney holding a J.D., LL.M. in Tax, and an MBA. Admitted in the U.S. Virgin Islands and multiple states, he has spent more than 25&nbsp;years helping individuals and businesses overcome debt.</p>
+        <p>"I believe in treating every client like family," Robert says. His philosophy centers on delivering straightforward advice with compassion and confidentiality.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="bg-gray">
+    <h2>The Pohl Approach</h2>
+    <ul class="why-list">
+      <li><strong>Personalized Attention</strong> – each case receives tailored strategies.</li>
+      <li><strong>Straightforward Advice</strong> – clear guidance without legal jargon.</li>
+      <li><strong>Confidential &amp; Compassionate</strong> – your situation is handled with care.</li>
+    </ul>
+  </section>
+
+  <section class="cta bg-white">
+    <p>Need advice on your situation? We're here to help – <strong>get your free consultation</strong>.</p>
+    <a href="index.html#contact-form" class="btn">Contact Us</a>
+  </section>
+
+  <footer>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `about.html` with head, header, and footer shared from the home page for consistent styling
- Introduce attorney biography section, "Pohl Approach" list, and call-to-action banner
- Include "Contact Us" button linking to the home page's contact section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894fd1a0f6c8321b450f0e24341ba56