### PR TITLE
Add personal bankruptcy service page and home link

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,6 +218,7 @@
           <li>Keep essential assets protected by exemptions</li>
           <li>Free confidential evaluation to see which chapter fits your situation</li>
         </ul>
+        <a href="personal-bankruptcy.html" class="btn">Learn More</a>
       </div>
       <div class="service-card">
         <h3>Business Bankruptcy</h3>

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Personal Bankruptcy | VI Bankruptcy</title>
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
+
+  <style>
+    :root {
+      --vi-1: #1B3940; /* Deep Teal */
+      --vi-2: #132326; /* Midnight */
+      --vi-3: #59453E; /* Brown‑Gray */
+      --vi-4: #A68D85; /* Taupe */
+      --vi-5: #D9C6BF; /* Shell */
+      --vi-gold: #BD9E07; /* accent line */
+      --vi-nav: #1C1F19; /* navigation bar */
+      --vi-gray: #F4F4F4; /* utility gray */
+    }
+
+    body {
+      margin: 0;
+      font-family: "Open Sans", Arial, sans-serif;
+      color: var(--vi-2);
+      line-height: 1.6;
+      background: #fff;
+    }
+
+    /* Background helpers */
+    .bg-white { background: #fff; color: var(--vi-2); }
+    .bg-gray  { background: var(--vi-gray); color: var(--vi-2); }
+
+    /* Header */
+    .site-header {
+      background: var(--vi-nav);
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.75rem 1.25rem;
+      border-bottom: 1px solid var(--vi-gold);
+    }
+    .site-header nav a {
+      color: #fff;
+      text-decoration: none;
+      margin-left: 1rem;
+      font-weight: 600;
+    }
+    .site-header nav a:hover { text-decoration: underline; }
+    .logo-link img { height: 48px; width: auto; }
+
+    /* Section base */
+    section { padding: 3rem 1.25rem; }
+
+    h1 {
+      font-family: "Cinzel", serif;
+      font-size: 2.5rem;
+      color: var(--vi-1);
+      margin-top: 0;
+      text-align: center;
+    }
+    h2 {
+      font-family: "Merriweather", serif;
+      font-weight: 700;
+      margin-top: 0;
+      font-size: 2rem;
+      color: var(--vi-1);
+      text-align: center;
+    }
+    h3 {
+      font-family: "Merriweather", serif;
+      font-size: 1.5rem;
+      margin-top: 0;
+      color: var(--vi-1);
+      text-align: center;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+    }
+
+    .chapter-list {
+      list-style: none;
+      padding: 0;
+      max-width: 800px;
+      margin: 1rem auto 0;
+      color: var(--vi-2);
+    }
+    .chapter-list li {
+      margin-bottom: 0.75rem;
+      padding-left: 1.5rem;
+      position: relative;
+    }
+    .chapter-list li:before {
+      content: "\2713"; /* checkmark */
+      position: absolute;
+      left: 0;
+      color: var(--vi-gold);
+    }
+
+    .faq { max-width: 800px; margin: 0 auto; }
+    .faq p { margin-bottom: 1rem; }
+
+    .cta { text-align: center; }
+    .btn {
+      display: inline-block;
+      background: var(--vi-1);
+      color: #fff;
+      padding: 0.75rem 1.5rem;
+      border-radius: 4px;
+      text-decoration: none;
+      font-weight: 600;
+      margin-top: 1rem;
+    }
+
+    footer {
+      background: var(--vi-nav);
+      color: #fff;
+      padding: 2rem 1.25rem;
+      font-size: 0.875rem;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <a href="/" class="logo-link">
+      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+    </a>
+    <nav>
+      <a href="index.html#services">Services</a>
+      <a href="index.html#why">Why Us</a>
+      <a href="index.html#testimonials">Testimonials</a>
+      <a href="index.html#contact">Contact</a>
+    </nav>
+  </header>
+
+  <section class="bg-white">
+    <h1>Personal Bankruptcy</h1>
+    <p style="text-align:center; max-width:700px; margin:0 auto;">Chapter 7 &amp; Chapter 13 for Individuals and Families</p>
+  </section>
+
+  <section class="bg-gray">
+    <h3><span style="font-size:2rem;">🛡️</span>Chapter 7 Bankruptcy</h3>
+    <ul class="chapter-list">
+      <li>Designed for those who cannot afford to repay debts.</li>
+      <li>Wipes out (discharges) most unsecured debts like credit cards, medical bills.</li>
+      <li>Typically completed in ~4 months.</li>
+      <li>Qualify via a "Means Test" (income threshold).</li>
+      <li><em>Most filers keep their essentials (home equity, car, retirement) thanks to exemptions.</em></li>
+    </ul>
+  </section>
+
+  <section class="bg-white">
+    <h3><span style="font-size:2rem;">🏠</span>Chapter 13 Bankruptcy</h3>
+    <ul class="chapter-list">
+      <li>A repayment plan to catch up on debts over 3-5 years.</li>
+      <li>Ideal for stopping foreclosure or spread out back payments on mortgages, car loans, etc.</li>
+      <li>You make affordable monthly payments to a trustee who pays your creditors.</li>
+      <li>Keep your property while making payments.</li>
+      <li>Must have regular income within debt limits.</li>
+    </ul>
+  </section>
+
+  <section class="bg-gray">
+    <h2>Common Questions</h2>
+    <div class="faq">
+      <p><strong>Q: Will I lose my house or car in bankruptcy?</strong></p>
+      <p>A: <strong>Not likely.</strong> Both Chapter 7 and 13 have provisions to protect your home/car (either via exemptions or the repayment plan). We'll explain based on your case.</p>
+
+      <p><strong>Q: Can bankruptcy help with student loans or tax debts?</strong></p>
+      <p>A: Student loans are generally not dischargeable (except in rare hardship cases). Some tax debts can be discharged if old enough; others can be included in a Chapter 13 plan.</p>
+
+      <p><strong>Q: How will bankruptcy affect my credit?</strong></p>
+      <p>A: It will be noted on your credit report (10 years for Chapter 7, 7 years for 13). However, many clients see their score start to improve within a year because they're no longer weighed down by delinquent accounts.</p>
+    </div>
+  </section>
+
+  <section class="cta bg-white">
+    <p>Bankruptcy is a legal tool to rebuild your life – not the end of the road. If you're unsure which option fits you, <strong>schedule a free consultation</strong> and we'll guide you through.</p>
+    <a href="index.html#contact-form" class="btn">Free Consultation</a>
+  </section>
+
+  <footer>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add dedicated personal-bankruptcy page covering Chapter 7 and Chapter 13 details, FAQs, and consultation CTA.
- Link the new page from the home page services section for easy navigation.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689503f8cf70832194e300b58f9aa2e1