### PR TITLE
Add dedicated testimonials page with CTA

### DIFF
--- a/about.html
+++ b/about.html
@@ -207,7 +207,7 @@
     <nav>
       <a href="index.html#services">Services</a>
       <a href="index.html#why">Why Us</a>
-      <a href="index.html#testimonials">Testimonials</a>
+      <a href="testimonials.html">Testimonials</a>
       <a href="index.html#contact">Contact</a>
     </nav>
   </header>

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -131,7 +131,7 @@
     <nav>
       <a href="index.html#services">Services</a>
       <a href="index.html#why">Why Us</a>
-      <a href="index.html#testimonials">Testimonials</a>
+      <a href="testimonials.html">Testimonials</a>
       <a href="index.html#contact">Contact</a>
     </nav>
   </header>

--- a/index.html
+++ b/index.html
@@ -130,13 +130,32 @@
       max-width: 900px;
       margin: 0 auto;
     }
+    .more-link { text-align: center; }
+    .more-link a { color: var(--vi-1); text-decoration: underline; }
     blockquote {
+      position: relative;
       margin: 0 0 1.5rem;
-      padding: 1.25rem 1.5rem;
+      padding: 1.25rem 1.5rem 1.25rem 2.75rem;
       background: var(--vi-1);
       border-left: 4px solid var(--vi-gold);
       font-style: italic;
       color: #fff;
+    }
+    blockquote::before {
+      content: "\201C";
+      position: absolute;
+      left: 1rem;
+      top: 0.5rem;
+      font-size: 2rem;
+      color: var(--vi-gold);
+      font-family: "Merriweather", serif;
+    }
+    blockquote cite {
+      display: block;
+      margin-top: 0.75rem;
+      font-style: normal;
+      font-weight: 600;
+      color: var(--vi-5);
     }
 
     /* CTA */
@@ -188,7 +207,7 @@
     <nav>
       <a href="#services">Services</a>
       <a href="#why">Why Us</a>
-      <a href="#testimonials">Testimonials</a>
+      <a href="testimonials.html">Testimonials</a>
       <a href="#contact">Contact</a>
     </nav>
   </header>
@@ -247,9 +266,15 @@
   <section id="testimonials" class="bg-white">
     <h2>Client Testimonials</h2>
     <div class="testimonials">
-      <blockquote>“Robert Pohl was a lifesaver, guiding me through Chapter&nbsp;7 and wiping out $50,000 in debt. I can finally breathe again.” — C.M., St.&nbsp;Thomas</blockquote>
-      <blockquote>“Our small business reorganized under Subchapter&nbsp;V and is thriving today thanks to Robert’s expertise.” — L.T., Christiansted</blockquote>
-      <p style="text-align:center;"><a href="#" style="color:var(--vi-1); text-decoration:underline;">Read more testimonials</a></p>
+      <blockquote>
+        <p>Robert Pohl was a lifesaver, guiding me through Chapter&nbsp;7 and wiping out $50,000 in debt. I can finally breathe again.</p>
+        <cite>&mdash; C.M., St.&nbsp;Thomas</cite>
+      </blockquote>
+      <blockquote>
+        <p>Our small business reorganized under Subchapter&nbsp;V and is thriving today thanks to Robert’s expertise.</p>
+        <cite>&mdash; L.T., Christiansted</cite>
+      </blockquote>
+      <p class="more-link"><a href="testimonials.html">Read more testimonials</a></p>
     </div>
   </section>
 

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -134,7 +134,7 @@
     <nav>
       <a href="index.html#services">Services</a>
       <a href="index.html#why">Why Us</a>
-      <a href="index.html#testimonials">Testimonials</a>
+      <a href="testimonials.html">Testimonials</a>
       <a href="index.html#contact">Contact</a>
     </nav>
   </header>

--- a/testimonials.html
+++ b/testimonials.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Testimonials | VI Bankruptcy</title>
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
+
+  <style>
+    :root {
+      --vi-1: #1B3940; /* Deep Teal */
+      --vi-2: #132326; /* Midnight */
+      --vi-3: #59453E; /* Brown‑Gray */
+      --vi-4: #A68D85; /* Taupe */
+      --vi-5: #D9C6BF; /* Shell */
+      --vi-gold: #BD9E07; /* accent line */
+      --vi-nav: #1C1F19; /* navigation bar */
+      --vi-gray: #F4F4F4; /* utility gray */
+    }
+
+    body {
+      margin: 0;
+      font-family: "Open Sans", Arial, sans-serif;
+      color: var(--vi-2);
+      line-height: 1.6;
+      background: #fff;
+    }
+
+    /* Background helpers */
+    .bg-white { background: #fff; color: var(--vi-2); }
+    .bg-gray  { background: var(--vi-gray); color: var(--vi-2); }
+
+    /* Header */
+    .site-header {
+      background: var(--vi-nav);
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.75rem 1.25rem;
+      border-bottom: 1px solid var(--vi-gold);
+    }
+    .site-header nav a {
+      color: #fff;
+      text-decoration: none;
+      margin-left: 1rem;
+      font-weight: 600;
+    }
+    .site-header nav a:hover { text-decoration: underline; }
+    .logo-link img { height: 48px; width: auto; }
+
+    /* Section base */
+    section { padding: 3rem 1.25rem; }
+
+    h1 {
+      font-family: "Merriweather", serif;
+      font-size: 2.5rem;
+      color: var(--vi-1);
+      text-align: center;
+      margin-top: 0;
+    }
+
+    .subtitle {
+      text-align: center;
+      margin-top: 0.5rem;
+      color: var(--vi-2);
+    }
+
+    /* Testimonials */
+    .testimonials {
+      max-width: 900px;
+      margin: 0 auto;
+    }
+    blockquote {
+      position: relative;
+      margin: 0 0 1.5rem;
+      padding: 1.25rem 1.5rem 1.25rem 2.75rem;
+      background: var(--vi-1);
+      border-left: 4px solid var(--vi-gold);
+      font-style: italic;
+      color: #fff;
+    }
+    blockquote::before {
+      content: "\201C";
+      position: absolute;
+      left: 1rem;
+      top: 0.5rem;
+      font-size: 2rem;
+      color: var(--vi-gold);
+      font-family: "Merriweather", serif;
+    }
+    blockquote cite {
+      display: block;
+      margin-top: 0.75rem;
+      font-style: normal;
+      font-weight: 600;
+      color: var(--vi-5);
+    }
+
+    /* CTA */
+    .cta { text-align: center; }
+    .btn {
+      display: inline-block;
+      background: var(--vi-1);
+      color: #fff;
+      padding: 0.75rem 1.5rem;
+      border-radius: 4px;
+      text-decoration: none;
+      font-weight: 600;
+      margin-top: 1rem;
+    }
+
+    /* Footer */
+    footer {
+      background: var(--vi-1);
+      color: #fff;
+      padding: 2rem 1.25rem;
+      font-size: 0.875rem;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <a href="/" class="logo-link">
+      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+    </a>
+    <nav>
+      <a href="index.html#services">Services</a>
+      <a href="index.html#why">Why Us</a>
+      <a href="testimonials.html">Testimonials</a>
+      <a href="index.html#contact">Contact</a>
+    </nav>
+  </header>
+
+  <section class="bg-white" id="testimonials">
+    <h1>Testimonials</h1>
+    <p class="subtitle">Hear from Our Clients</p>
+    <div class="testimonials">
+      <blockquote>
+        <p><strong>I was drowning in debt and considering bankruptcy as a last resort. Robert Pohl treated me with respect and patience from day one.</strong> He answered all my questions and guided me through a Chapter&nbsp;7 bankruptcy that wiped out almost $50,000 of credit card and medical bills. I'm now debt-free and it feels like I can breathe again. I highly recommend Mr.&nbsp;Pohl to anyone in the Virgin Islands who needs help.</p>
+        <cite>&mdash; C.M., St.&nbsp;Thomas</cite>
+      </blockquote>
+      <blockquote>
+        <p><strong>Our small business in St.&nbsp;Croix was hit hard in 2020 and we fell behind on loans and taxes.</strong> Robert helped us file a Subchapter&nbsp;V bankruptcy. We stayed open, reorganized our debts, and a year later, our business is stable and thriving. We are so grateful for the second chance.</p>
+        <cite>&mdash; L.T., Christiansted</cite>
+      </blockquote>
+    </div>
+  </section>
+
+  <section class="cta bg-white">
+    <p>Your story could be next. Let us help you write a debt-free future.</p>
+    <a href="index.html#contact-form" class="btn">Contact Us</a>
+  </section>
+
+  <footer>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Style testimonials with decorative quotes and clear citation formatting
- Refactor testimonials link styling and tighten heading/subtitle presentation
- Point navigation across pages to the dedicated testimonials page for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895077c6d9083219c6be6e3de13c3dd