### PR TITLE
Add privacy and disclaimer pages with footer links

### DIFF
--- a/about.html
+++ b/about.html
@@ -240,7 +240,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
   </footer>
 </body>
 </html>

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -178,7 +178,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
   </footer>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -160,7 +160,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
   </footer>
 
   <script>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Pay Online | VI Bankruptcy</title>
+  <title>Disclaimer | VI Bankruptcy</title>
 
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -14,8 +14,12 @@
     :root {
       --vi-1: #1B3940; /* Deep Teal */
       --vi-2: #132326; /* Midnight */
+      --vi-3: #59453E; /* Brown‑Gray */
+      --vi-4: #A68D85; /* Taupe */
+      --vi-5: #D9C6BF; /* Shell */
       --vi-gold: #BD9E07; /* accent line */
       --vi-nav: #1C1F19; /* navigation bar */
+      --vi-gray: #F4F4F4; /* utility gray */
     }
 
     body {
@@ -25,6 +29,9 @@
       line-height: 1.6;
       background: #fff;
     }
+
+    .bg-white { background: #fff; color: var(--vi-2); }
+    .bg-gray  { background: var(--vi-gray); color: var(--vi-2); }
 
     .site-header {
       background: var(--vi-nav);
@@ -44,25 +51,7 @@
     .site-header nav a:hover { text-decoration: underline; }
     .logo-link img { height: 48px; width: auto; }
 
-    .btn {
-      display: inline-block;
-      background: var(--vi-1);
-      color: #fff;
-      padding: 0.75rem 1.5rem;
-      border-radius: 4px;
-      text-decoration: none;
-      font-weight: 600;
-    }
-
-    section { padding: 3rem 1.25rem; text-align: center; }
-
-    footer {
-      background: var(--vi-nav);
-      color: #fff;
-      padding: 2rem 1.25rem;
-      font-size: 0.875rem;
-      text-align: center;
-    }
+    section { padding: 3rem 1.25rem; }
   </style>
 </head>
 <body>
@@ -79,12 +68,12 @@
     </nav>
   </header>
 
-  <section>
-    <h1>Pay Online</h1>
-    <p>Use our secure payment portal to pay your invoice or bankruptcy filing fee. Enter your name or case number to ensure proper credit of your payment.</p>
-    <div style="margin-top:1.5rem;">
-      <a href="https://secure.lawpay.com/pages/robert-pohl-law/vi-bankruptcy" class="btn" target="_blank" rel="noopener">Pay Now</a>
-    </div>
+  <section class="bg-white">
+    <h1 style="text-align:center;">Disclaimer</h1>
+    <p>The information on this website is provided for general informational purposes only and should not be construed as legal advice on any subject matter. You should not act or refrain from acting on the basis of any content included in this site without seeking appropriate legal or other professional advice.</p>
+    <p>Use of this website or contacting the Law Office of Robert Pohl through this site does not create an attorney-client relationship. Please do not send confidential or time-sensitive information until such a relationship has been established.</p>
+    <p>While we strive to keep the information on this site current, we make no guarantees about the accuracy or completeness of the information and disclaim liability for errors or omissions. Links to external websites are provided for convenience and do not imply endorsement.</p>
+    <p><em>This website may be considered attorney advertising in some jurisdictions. Past results do not guarantee similar outcomes.</em></p>
   </section>
 
   <footer>

--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
   </footer>
 </body>
 </html>

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -187,7 +187,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
   </footer>
 </body>
 </html>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Pay Online | VI Bankruptcy</title>
+  <title>Privacy Policy | VI Bankruptcy</title>
 
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -14,8 +14,12 @@
     :root {
       --vi-1: #1B3940; /* Deep Teal */
       --vi-2: #132326; /* Midnight */
+      --vi-3: #59453E; /* Brown‑Gray */
+      --vi-4: #A68D85; /* Taupe */
+      --vi-5: #D9C6BF; /* Shell */
       --vi-gold: #BD9E07; /* accent line */
       --vi-nav: #1C1F19; /* navigation bar */
+      --vi-gray: #F4F4F4; /* utility gray */
     }
 
     body {
@@ -25,6 +29,9 @@
       line-height: 1.6;
       background: #fff;
     }
+
+    .bg-white { background: #fff; color: var(--vi-2); }
+    .bg-gray  { background: var(--vi-gray); color: var(--vi-2); }
 
     .site-header {
       background: var(--vi-nav);
@@ -44,25 +51,7 @@
     .site-header nav a:hover { text-decoration: underline; }
     .logo-link img { height: 48px; width: auto; }
 
-    .btn {
-      display: inline-block;
-      background: var(--vi-1);
-      color: #fff;
-      padding: 0.75rem 1.5rem;
-      border-radius: 4px;
-      text-decoration: none;
-      font-weight: 600;
-    }
-
-    section { padding: 3rem 1.25rem; text-align: center; }
-
-    footer {
-      background: var(--vi-nav);
-      color: #fff;
-      padding: 2rem 1.25rem;
-      font-size: 0.875rem;
-      text-align: center;
-    }
+    section { padding: 3rem 1.25rem; }
   </style>
 </head>
 <body>
@@ -79,12 +68,12 @@
     </nav>
   </header>
 
-  <section>
-    <h1>Pay Online</h1>
-    <p>Use our secure payment portal to pay your invoice or bankruptcy filing fee. Enter your name or case number to ensure proper credit of your payment.</p>
-    <div style="margin-top:1.5rem;">
-      <a href="https://secure.lawpay.com/pages/robert-pohl-law/vi-bankruptcy" class="btn" target="_blank" rel="noopener">Pay Now</a>
-    </div>
+  <section class="bg-white">
+    <h1 style="text-align:center;">Privacy Policy</h1>
+    <p>The Law Office of Robert Pohl respects your privacy. We collect information that you voluntarily provide, such as through contact forms, emails, or phone calls. This information is used solely to respond to your inquiries and to provide legal services. We do not sell or share personal information with third parties.</p>
+    <p>Basic website analytics may be used to understand visitor trends, but these tools do not identify individual users. Submitting information through this site does not create an attorney-client relationship. Please do not send confidential information until an attorney-client relationship has been established.</p>
+    <p>We may update this policy from time to time. Continued use of the site constitutes acceptance of any changes. For questions about this policy, please contact us directly.</p>
+    <p><em>This website may be considered attorney advertising in some jurisdictions. Past results do not guarantee similar outcomes.</em></p>
   </section>
 
   <footer>

--- a/testimonials.html
+++ b/testimonials.html
@@ -159,7 +159,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Privacy Policy page describing data use and including attorney advertising notice
- add Disclaimer page clarifying informational purpose and attorney advertising
- link Privacy Policy and Disclaimer from footer across all pages

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895118a4c948321a6c793b02071ebb9