### PR TITLE
Add Ready to File checklist page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -127,6 +127,7 @@
           St. John: By appointment
         </p>
         <p><strong>Hours:</strong> Mon–Fri 9am–5pm AST (and by appointment)</p>
+        <p><a href="ready-to-file.html" style="color:#fff; text-decoration:underline;">View our "Ready to File" checklist</a> to prepare your paperwork before your appointment.</p>
         <div class="map">
           <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3793.381593432963!2d-64.91999928459224!3d18.33299857801429!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x8c0510adb88ae201%3A0x9b9d054b022b35c6!2s5316%20Yacht%20Haven%20Grande%2C%20St%20Thomas%2C%20VI%2000802!5e0!3m2!1sen!2sus!4v1712500000000!5m2!1sen!2sus" allowfullscreen="" loading="lazy"></iframe>
         </div>

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ready to File? Checklist | VI Bankruptcy</title>
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
+
+  <style>
+    :root {
+      --vi-1: #1B3940; /* Deep Teal */
+      --vi-2: #132326; /* Midnight */
+      --vi-3: #59453E; /* Brown‑Gray */
+      --vi-4: #A68D85; /* Taupe */
+      --vi-5: #D9C6BF; /* Shell */
+      --vi-gold: #BD9E07; /* accent line */
+      --vi-nav: #1C1F19; /* navigation bar */
+      --vi-gray: #F4F4F4; /* utility gray */
+    }
+
+    body {
+      margin: 0;
+      font-family: "Open Sans", Arial, sans-serif;
+      color: var(--vi-2);
+      line-height: 1.6;
+      background: #fff;
+    }
+
+    .site-header {
+      background: var(--vi-nav);
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.75rem 1.25rem;
+      border-bottom: 1px solid var(--vi-gold);
+    }
+    .site-header nav a {
+      color: #fff;
+      text-decoration: none;
+      margin-left: 1rem;
+      font-weight: 600;
+    }
+    .site-header nav a:hover { text-decoration: underline; }
+    .logo-link img { height: 48px; width: auto; }
+
+    section { padding: 3rem 1.25rem; }
+    h1, h2 { font-family: "Merriweather", serif; }
+    .section-title { text-align: center; color: #fff; margin-bottom: 0; }
+    .section-subtitle { text-align: center; color: var(--vi-5); margin-top: 0.25rem; }
+    .bg-midnight { background: var(--vi-2); color: #fff; }
+    .bg-gray { background: var(--vi-gray); }
+
+    ul { max-width: 600px; margin: 0 auto 1.5rem; }
+    ul li { margin-bottom: 0.5rem; }
+
+    .btn {
+      display: inline-block;
+      background: var(--vi-1);
+      color: #fff;
+      padding: 0.75rem 1.5rem;
+      border-radius: 4px;
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    footer {
+      background: var(--vi-1);
+      color: #fff;
+      padding: 2rem 1.25rem;
+      font-size: 0.875rem;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <a href="/" class="logo-link">
+      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+    </a>
+    <nav>
+      <a href="index.html#services">Services</a>
+      <a href="index.html#why">Why Us</a>
+      <a href="testimonials.html">Testimonials</a>
+      <a href="contact.html">Contact</a>
+      <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
+    </nav>
+  </header>
+
+  <section class="bg-midnight">
+    <h1 class="section-title">Ready to File? Checklist</h1>
+    <p class="section-subtitle">Get organized and take the first steps toward a fresh start.</p>
+  </section>
+
+  <section class="bg-gray">
+    <h2>Gather These Documents</h2>
+    <ul>
+      <li>Recent pay stubs or proof of income</li>
+      <li>Tax returns from the last two years</li>
+      <li>Recent bank statements</li>
+      <li>A list of all assets and debts</li>
+      <li>Any lawsuits, judgments, or collection notices</li>
+    </ul>
+
+    <h2>Complete Credit Counseling</h2>
+    <p>Before filing, the U.S. Bankruptcy Code requires you to complete a brief credit counseling course. This can usually be done online or by phone. Visit the <a href="https://www.justice.gov/ust/credit-counseling-debtor-education-information" target="_blank" rel="noopener">U.S. Trustee's list of approved providers for the Virgin Islands</a> to choose an agency. After filing, you'll also need a Debtor Education course before discharge.</p>
+
+    <h2>Steps to Get Started</h2>
+    <ul>
+      <li>Gather your financial documents.</li>
+      <li>Complete the required credit counseling.</li>
+      <li>Consult with our attorney to prepare your bankruptcy petition.</li>
+    </ul>
+
+    <div style="text-align:center; margin-top:2rem;">
+      <a href="contact.html" class="btn">Schedule a Consultation</a>
+    </div>
+  </section>
+
+  <footer>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `ready-to-file.html` page detailing documents and credit counseling steps for bankruptcy preparation.
- Link the new checklist from the Contact page for easy access.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689512bda260832181a6e1ac8849fbba