### PR TITLE
Add bankruptcy FAQ page with site-wide link

### DIFF
--- a/about.html
+++ b/about.html
@@ -208,6 +208,7 @@
         <a href="index.html#services">Services</a>
         <a href="index.html#why">Why Us</a>
         <a href="testimonials.html">Testimonials</a>
+        <a href="faq.html">FAQ</a>
         <a href="contact.html">Contact</a>
         <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -132,6 +132,7 @@
         <a href="index.html#services">Services</a>
         <a href="index.html#why">Why Us</a>
         <a href="testimonials.html">Testimonials</a>
+        <a href="faq.html">FAQ</a>
         <a href="contact.html">Contact</a>
         <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>

--- a/contact.html
+++ b/contact.html
@@ -109,6 +109,7 @@
       <a href="index.html#services">Services</a>
       <a href="index.html#why">Why Us</a>
       <a href="testimonials.html">Testimonials</a>
+        <a href="faq.html">FAQ</a>
       <a href="contact.html">Contact</a>
         <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -63,6 +63,7 @@
         <a href="index.html#services">Services</a>
         <a href="index.html#why">Why Us</a>
         <a href="testimonials.html">Testimonials</a>
+        <a href="faq.html">FAQ</a>
         <a href="contact.html">Contact</a>
         <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>

--- a/faq.html
+++ b/faq.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bankruptcy FAQ | VI Bankruptcy</title>
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
+
+  <style>
+    :root {
+      --vi-1: #1B3940; /* Deep Teal */
+      --vi-2: #132326; /* Midnight */
+      --vi-3: #59453E; /* Brown‑Gray */
+      --vi-4: #A68D85; /* Taupe */
+      --vi-5: #D9C6BF; /* Shell */
+      --vi-gold: #BD9E07; /* accent line */
+      --vi-nav: #1C1F19; /* navigation bar */
+      --vi-gray: #F4F4F4; /* utility gray */
+    }
+
+    body {
+      margin: 0;
+      font-family: "Open Sans", Arial, sans-serif;
+      color: var(--vi-2);
+      line-height: 1.6;
+      background: #fff;
+    }
+
+    .site-header {
+      background: var(--vi-nav);
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.75rem 1.25rem;
+      border-bottom: 1px solid var(--vi-gold);
+    }
+    .site-header nav a {
+      color: #fff;
+      text-decoration: none;
+      margin-left: 1rem;
+      font-weight: 600;
+    }
+    .site-header nav a:hover { text-decoration: underline; }
+    .logo-link img { height: 48px; width: auto; }
+
+    section { padding: 3rem 1.25rem; }
+    .bg-white { background: #fff; color: var(--vi-2); }
+    h1 { text-align:center; font-family: "Merriweather", serif; color: var(--vi-1); }
+    details { max-width: 800px; margin: 0 auto 1rem; border-bottom:1px solid var(--vi-gold); padding-bottom:1rem; }
+    details summary { font-weight:600; cursor:pointer; }
+    .cta { text-align: center; }
+    .btn {
+      display: inline-block;
+      background: var(--vi-1);
+      color: #fff;
+      padding: 0.75rem 1.5rem;
+      border-radius: 4px;
+      text-decoration: none;
+    }
+
+    footer {
+      background: var(--vi-nav);
+      color: #fff;
+      text-align: center;
+      padding: 1rem;
+    }
+    footer a { color: #fff; text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <a href="/" class="logo-link">
+      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+    </a>
+    <nav>
+        <a href="index.html#services">Services</a>
+        <a href="index.html#why">Why Us</a>
+        <a href="testimonials.html">Testimonials</a>
+        <a href="faq.html">FAQ</a>
+        <a href="contact.html">Contact</a>
+        <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
+    </nav>
+  </header>
+
+  <section class="bg-white" id="faq">
+    <h1>Bankruptcy FAQ</h1>
+    <details>
+      <summary>Will everyone know I filed bankruptcy?</summary>
+      <p>For the most part, no. Bankruptcies are public records, but unless someone is specifically looking, your friends or employer won’t be automatically notified. However, notices do go to your creditors and co‑debtors.</p>
+    </details>
+    <details>
+      <summary>Can I ever get credit again after bankruptcy?</summary>
+      <p>Yes, absolutely. Many clients receive credit offers soon after their case because they have less debt. Rebuilding credit is possible within a year or two by practicing good financial habits.</p>
+    </details>
+    <details>
+      <summary>Will I lose my house or car in bankruptcy?</summary>
+      <p>Not likely. Both Chapter&nbsp;7 and 13 have provisions to protect your home or car, either through exemptions or a repayment plan. We'll explain based on your case.</p>
+    </details>
+    <details>
+      <summary>Can bankruptcy help with student loans or tax debts?</summary>
+      <p>Student loans are generally not dischargeable except in rare hardship cases. Some tax debts can be discharged if old enough; others can be included in a Chapter&nbsp;13 plan.</p>
+    </details>
+    <details>
+      <summary>How will bankruptcy affect my credit?</summary>
+      <p>It will be noted on your credit report (10 years for Chapter&nbsp;7, 7 years for Chapter&nbsp;13). However, many clients see their score start to improve within a year because they’re no longer weighed down by delinquent accounts.</p>
+    </details>
+  </section>
+
+  <section class="cta bg-white">
+    <h2>Still Have Questions?</h2>
+    <p>Your first consultation is free and confidential.</p>
+    <a href="contact.html" class="btn">Request Your Free Consultation</a>
+  </section>
+
+  <footer>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -208,6 +208,7 @@
         <a href="#services">Services</a>
         <a href="#why">Why Us</a>
         <a href="testimonials.html">Testimonials</a>
+        <a href="faq.html">FAQ</a>
         <a href="contact.html">Contact</a>
         <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>

--- a/pay-online.html
+++ b/pay-online.html
@@ -74,6 +74,7 @@
         <a href="index.html#services">Services</a>
         <a href="index.html#why">Why Us</a>
         <a href="testimonials.html">Testimonials</a>
+        <a href="faq.html">FAQ</a>
         <a href="contact.html">Contact</a>
         <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -135,6 +135,7 @@
         <a href="index.html#services">Services</a>
         <a href="index.html#why">Why Us</a>
         <a href="testimonials.html">Testimonials</a>
+        <a href="faq.html">FAQ</a>
         <a href="contact.html">Contact</a>
         <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -63,6 +63,7 @@
         <a href="index.html#services">Services</a>
         <a href="index.html#why">Why Us</a>
         <a href="testimonials.html">Testimonials</a>
+        <a href="faq.html">FAQ</a>
         <a href="contact.html">Contact</a>
         <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -86,6 +86,7 @@
       <a href="index.html#services">Services</a>
       <a href="index.html#why">Why Us</a>
       <a href="testimonials.html">Testimonials</a>
+        <a href="faq.html">FAQ</a>
       <a href="contact.html">Contact</a>
       <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>

--- a/testimonials.html
+++ b/testimonials.html
@@ -133,6 +133,7 @@
         <a href="index.html#services">Services</a>
         <a href="index.html#why">Why Us</a>
         <a href="testimonials.html">Testimonials</a>
+        <a href="faq.html">FAQ</a>
         <a href="contact.html">Contact</a>
         <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>


### PR DESCRIPTION
## Summary
- add dedicated `faq.html` with expandable Q&A and consultation CTA
- link FAQ from navigation across the site for easy access

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895141a50848321874b69c14a795ab3