### PR TITLE
Add service dropdown and contact page link to navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -51,6 +51,23 @@
       font-weight: 600;
     }
     .site-header nav a:hover { text-decoration: underline; }
+    .site-header nav .dropdown { position: relative; display: inline-block; }
+    .site-header nav .dropdown-content {
+      display: none;
+      position: absolute;
+      background: var(--vi-nav);
+      padding: 0.5rem 0;
+      min-width: 200px;
+      z-index: 1;
+    }
+    .site-header nav .dropdown-content a {
+      color: #fff;
+      text-decoration: none;
+      display: block;
+      margin: 0;
+      padding: 0.5rem 1rem;
+    }
+    .site-header nav .dropdown:hover .dropdown-content { display: block; }
     .logo-link img { height: 48px; width: auto; }
 
     /* Hero */
@@ -205,12 +222,18 @@
       <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
-        <a href="index.html#services">Services</a>
-        <a href="index.html#why">Why Us</a>
-        <a href="testimonials.html">Testimonials</a>
-        <a href="faq.html">FAQ</a>
-        <a href="contact.html">Contact</a>
-        <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
+      <a href="about.html">About</a>
+      <div class="dropdown">
+        <a href="javascript:void(0)">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="personal-bankruptcy.html">Personal Bankruptcy</a>
+          <a href="business-bankruptcy.html">Business Bankruptcy</a>
+        </div>
+      </div>
+      <a href="testimonials.html">Testimonials</a>
+      <a href="faq.html">FAQ</a>
+      <a href="contact.html">Contact</a>
+      <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>
   </header>
 

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -51,6 +51,23 @@
       font-weight: 600;
     }
     .site-header nav a:hover { text-decoration: underline; }
+    .site-header nav .dropdown { position: relative; display: inline-block; }
+    .site-header nav .dropdown-content {
+      display: none;
+      position: absolute;
+      background: var(--vi-nav);
+      padding: 0.5rem 0;
+      min-width: 200px;
+      z-index: 1;
+    }
+    .site-header nav .dropdown-content a {
+      color: #fff;
+      text-decoration: none;
+      display: block;
+      margin: 0;
+      padding: 0.5rem 1rem;
+    }
+    .site-header nav .dropdown:hover .dropdown-content { display: block; }
     .logo-link img { height: 48px; width: auto; }
 
     /* Section base */
@@ -129,12 +146,18 @@
       <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
-        <a href="index.html#services">Services</a>
-        <a href="index.html#why">Why Us</a>
-        <a href="testimonials.html">Testimonials</a>
-        <a href="faq.html">FAQ</a>
-        <a href="contact.html">Contact</a>
-        <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
+      <a href="about.html">About</a>
+      <div class="dropdown">
+        <a href="javascript:void(0)">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="personal-bankruptcy.html">Personal Bankruptcy</a>
+          <a href="business-bankruptcy.html">Business Bankruptcy</a>
+        </div>
+      </div>
+      <a href="testimonials.html">Testimonials</a>
+      <a href="faq.html">FAQ</a>
+      <a href="contact.html">Contact</a>
+      <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>
   </header>
 

--- a/contact.html
+++ b/contact.html
@@ -46,6 +46,23 @@
       font-weight: 600;
     }
     .site-header nav a:hover { text-decoration: underline; }
+    .site-header nav .dropdown { position: relative; display: inline-block; }
+    .site-header nav .dropdown-content {
+      display: none;
+      position: absolute;
+      background: var(--vi-nav);
+      padding: 0.5rem 0;
+      min-width: 200px;
+      z-index: 1;
+    }
+    .site-header nav .dropdown-content a {
+      color: #fff;
+      text-decoration: none;
+      display: block;
+      margin: 0;
+      padding: 0.5rem 1rem;
+    }
+    .site-header nav .dropdown:hover .dropdown-content { display: block; }
     .logo-link img { height: 48px; width: auto; }
 
     .btn {
@@ -106,12 +123,18 @@
       <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
-      <a href="index.html#services">Services</a>
-      <a href="index.html#why">Why Us</a>
+      <a href="about.html">About</a>
+      <div class="dropdown">
+        <a href="javascript:void(0)">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="personal-bankruptcy.html">Personal Bankruptcy</a>
+          <a href="business-bankruptcy.html">Business Bankruptcy</a>
+        </div>
+      </div>
       <a href="testimonials.html">Testimonials</a>
-        <a href="faq.html">FAQ</a>
+      <a href="faq.html">FAQ</a>
       <a href="contact.html">Contact</a>
-        <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
+      <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>
   </header>
 

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -49,6 +49,23 @@
       font-weight: 600;
     }
     .site-header nav a:hover { text-decoration: underline; }
+    .site-header nav .dropdown { position: relative; display: inline-block; }
+    .site-header nav .dropdown-content {
+      display: none;
+      position: absolute;
+      background: var(--vi-nav);
+      padding: 0.5rem 0;
+      min-width: 200px;
+      z-index: 1;
+    }
+    .site-header nav .dropdown-content a {
+      color: #fff;
+      text-decoration: none;
+      display: block;
+      margin: 0;
+      padding: 0.5rem 1rem;
+    }
+    .site-header nav .dropdown:hover .dropdown-content { display: block; }
     .logo-link img { height: 48px; width: auto; }
 
     section { padding: 3rem 1.25rem; }
@@ -60,12 +77,18 @@
       <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
-        <a href="index.html#services">Services</a>
-        <a href="index.html#why">Why Us</a>
-        <a href="testimonials.html">Testimonials</a>
-        <a href="faq.html">FAQ</a>
-        <a href="contact.html">Contact</a>
-        <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
+      <a href="about.html">About</a>
+      <div class="dropdown">
+        <a href="javascript:void(0)">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="personal-bankruptcy.html">Personal Bankruptcy</a>
+          <a href="business-bankruptcy.html">Business Bankruptcy</a>
+        </div>
+      </div>
+      <a href="testimonials.html">Testimonials</a>
+      <a href="faq.html">FAQ</a>
+      <a href="contact.html">Contact</a>
+      <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>
   </header>
 

--- a/faq.html
+++ b/faq.html
@@ -46,6 +46,23 @@
       font-weight: 600;
     }
     .site-header nav a:hover { text-decoration: underline; }
+    .site-header nav .dropdown { position: relative; display: inline-block; }
+    .site-header nav .dropdown-content {
+      display: none;
+      position: absolute;
+      background: var(--vi-nav);
+      padding: 0.5rem 0;
+      min-width: 200px;
+      z-index: 1;
+    }
+    .site-header nav .dropdown-content a {
+      color: #fff;
+      text-decoration: none;
+      display: block;
+      margin: 0;
+      padding: 0.5rem 1rem;
+    }
+    .site-header nav .dropdown:hover .dropdown-content { display: block; }
     .logo-link img { height: 48px; width: auto; }
 
     section { padding: 3rem 1.25rem; }
@@ -78,12 +95,18 @@
       <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
-        <a href="index.html#services">Services</a>
-        <a href="index.html#why">Why Us</a>
-        <a href="testimonials.html">Testimonials</a>
-        <a href="faq.html">FAQ</a>
-        <a href="contact.html">Contact</a>
-        <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
+      <a href="about.html">About</a>
+      <div class="dropdown">
+        <a href="javascript:void(0)">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="personal-bankruptcy.html">Personal Bankruptcy</a>
+          <a href="business-bankruptcy.html">Business Bankruptcy</a>
+        </div>
+      </div>
+      <a href="testimonials.html">Testimonials</a>
+      <a href="faq.html">FAQ</a>
+      <a href="contact.html">Contact</a>
+      <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>
   </header>
 

--- a/index.html
+++ b/index.html
@@ -51,6 +51,23 @@
       font-weight: 600;
     }
     .site-header nav a:hover { text-decoration: underline; }
+    .site-header nav .dropdown { position: relative; display: inline-block; }
+    .site-header nav .dropdown-content {
+      display: none;
+      position: absolute;
+      background: var(--vi-nav);
+      padding: 0.5rem 0;
+      min-width: 200px;
+      z-index: 1;
+    }
+    .site-header nav .dropdown-content a {
+      color: #fff;
+      text-decoration: none;
+      display: block;
+      margin: 0;
+      padding: 0.5rem 1rem;
+    }
+    .site-header nav .dropdown:hover .dropdown-content { display: block; }
     .logo-link img { height: 48px; width: auto; }
 
     /* Hero */
@@ -205,12 +222,18 @@
       <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
-        <a href="#services">Services</a>
-        <a href="#why">Why Us</a>
-        <a href="testimonials.html">Testimonials</a>
-        <a href="faq.html">FAQ</a>
-        <a href="contact.html">Contact</a>
-        <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
+      <a href="about.html">About</a>
+      <div class="dropdown">
+        <a href="javascript:void(0)">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="personal-bankruptcy.html">Personal Bankruptcy</a>
+          <a href="business-bankruptcy.html">Business Bankruptcy</a>
+        </div>
+      </div>
+      <a href="testimonials.html">Testimonials</a>
+      <a href="faq.html">FAQ</a>
+      <a href="contact.html">Contact</a>
+      <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>
   </header>
 

--- a/pay-online.html
+++ b/pay-online.html
@@ -42,6 +42,23 @@
       font-weight: 600;
     }
     .site-header nav a:hover { text-decoration: underline; }
+    .site-header nav .dropdown { position: relative; display: inline-block; }
+    .site-header nav .dropdown-content {
+      display: none;
+      position: absolute;
+      background: var(--vi-nav);
+      padding: 0.5rem 0;
+      min-width: 200px;
+      z-index: 1;
+    }
+    .site-header nav .dropdown-content a {
+      color: #fff;
+      text-decoration: none;
+      display: block;
+      margin: 0;
+      padding: 0.5rem 1rem;
+    }
+    .site-header nav .dropdown:hover .dropdown-content { display: block; }
     .logo-link img { height: 48px; width: auto; }
 
     .btn {
@@ -71,12 +88,18 @@
       <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
-        <a href="index.html#services">Services</a>
-        <a href="index.html#why">Why Us</a>
-        <a href="testimonials.html">Testimonials</a>
-        <a href="faq.html">FAQ</a>
-        <a href="contact.html">Contact</a>
-        <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
+      <a href="about.html">About</a>
+      <div class="dropdown">
+        <a href="javascript:void(0)">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="personal-bankruptcy.html">Personal Bankruptcy</a>
+          <a href="business-bankruptcy.html">Business Bankruptcy</a>
+        </div>
+      </div>
+      <a href="testimonials.html">Testimonials</a>
+      <a href="faq.html">FAQ</a>
+      <a href="contact.html">Contact</a>
+      <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>
   </header>
 

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -51,6 +51,23 @@
       font-weight: 600;
     }
     .site-header nav a:hover { text-decoration: underline; }
+    .site-header nav .dropdown { position: relative; display: inline-block; }
+    .site-header nav .dropdown-content {
+      display: none;
+      position: absolute;
+      background: var(--vi-nav);
+      padding: 0.5rem 0;
+      min-width: 200px;
+      z-index: 1;
+    }
+    .site-header nav .dropdown-content a {
+      color: #fff;
+      text-decoration: none;
+      display: block;
+      margin: 0;
+      padding: 0.5rem 1rem;
+    }
+    .site-header nav .dropdown:hover .dropdown-content { display: block; }
     .logo-link img { height: 48px; width: auto; }
 
     /* Section base */
@@ -132,12 +149,18 @@
       <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
-        <a href="index.html#services">Services</a>
-        <a href="index.html#why">Why Us</a>
-        <a href="testimonials.html">Testimonials</a>
-        <a href="faq.html">FAQ</a>
-        <a href="contact.html">Contact</a>
-        <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
+      <a href="about.html">About</a>
+      <div class="dropdown">
+        <a href="javascript:void(0)">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="personal-bankruptcy.html">Personal Bankruptcy</a>
+          <a href="business-bankruptcy.html">Business Bankruptcy</a>
+        </div>
+      </div>
+      <a href="testimonials.html">Testimonials</a>
+      <a href="faq.html">FAQ</a>
+      <a href="contact.html">Contact</a>
+      <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>
   </header>
 

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -49,6 +49,23 @@
       font-weight: 600;
     }
     .site-header nav a:hover { text-decoration: underline; }
+    .site-header nav .dropdown { position: relative; display: inline-block; }
+    .site-header nav .dropdown-content {
+      display: none;
+      position: absolute;
+      background: var(--vi-nav);
+      padding: 0.5rem 0;
+      min-width: 200px;
+      z-index: 1;
+    }
+    .site-header nav .dropdown-content a {
+      color: #fff;
+      text-decoration: none;
+      display: block;
+      margin: 0;
+      padding: 0.5rem 1rem;
+    }
+    .site-header nav .dropdown:hover .dropdown-content { display: block; }
     .logo-link img { height: 48px; width: auto; }
 
     section { padding: 3rem 1.25rem; }
@@ -60,12 +77,18 @@
       <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
-        <a href="index.html#services">Services</a>
-        <a href="index.html#why">Why Us</a>
-        <a href="testimonials.html">Testimonials</a>
-        <a href="faq.html">FAQ</a>
-        <a href="contact.html">Contact</a>
-        <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
+      <a href="about.html">About</a>
+      <div class="dropdown">
+        <a href="javascript:void(0)">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="personal-bankruptcy.html">Personal Bankruptcy</a>
+          <a href="business-bankruptcy.html">Business Bankruptcy</a>
+        </div>
+      </div>
+      <a href="testimonials.html">Testimonials</a>
+      <a href="faq.html">FAQ</a>
+      <a href="contact.html">Contact</a>
+      <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>
   </header>
 

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -46,6 +46,23 @@
       font-weight: 600;
     }
     .site-header nav a:hover { text-decoration: underline; }
+    .site-header nav .dropdown { position: relative; display: inline-block; }
+    .site-header nav .dropdown-content {
+      display: none;
+      position: absolute;
+      background: var(--vi-nav);
+      padding: 0.5rem 0;
+      min-width: 200px;
+      z-index: 1;
+    }
+    .site-header nav .dropdown-content a {
+      color: #fff;
+      text-decoration: none;
+      display: block;
+      margin: 0;
+      padding: 0.5rem 1rem;
+    }
+    .site-header nav .dropdown:hover .dropdown-content { display: block; }
     .logo-link img { height: 48px; width: auto; }
 
     section { padding: 3rem 1.25rem; }
@@ -83,10 +100,16 @@
       <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
-      <a href="index.html#services">Services</a>
-      <a href="index.html#why">Why Us</a>
+      <a href="about.html">About</a>
+      <div class="dropdown">
+        <a href="javascript:void(0)">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="personal-bankruptcy.html">Personal Bankruptcy</a>
+          <a href="business-bankruptcy.html">Business Bankruptcy</a>
+        </div>
+      </div>
       <a href="testimonials.html">Testimonials</a>
-        <a href="faq.html">FAQ</a>
+      <a href="faq.html">FAQ</a>
       <a href="contact.html">Contact</a>
       <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>

--- a/testimonials.html
+++ b/testimonials.html
@@ -51,6 +51,23 @@
       font-weight: 600;
     }
     .site-header nav a:hover { text-decoration: underline; }
+    .site-header nav .dropdown { position: relative; display: inline-block; }
+    .site-header nav .dropdown-content {
+      display: none;
+      position: absolute;
+      background: var(--vi-nav);
+      padding: 0.5rem 0;
+      min-width: 200px;
+      z-index: 1;
+    }
+    .site-header nav .dropdown-content a {
+      color: #fff;
+      text-decoration: none;
+      display: block;
+      margin: 0;
+      padding: 0.5rem 1rem;
+    }
+    .site-header nav .dropdown:hover .dropdown-content { display: block; }
     .logo-link img { height: 48px; width: auto; }
 
     /* Section base */
@@ -130,12 +147,18 @@
       <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
-        <a href="index.html#services">Services</a>
-        <a href="index.html#why">Why Us</a>
-        <a href="testimonials.html">Testimonials</a>
-        <a href="faq.html">FAQ</a>
-        <a href="contact.html">Contact</a>
-        <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
+      <a href="about.html">About</a>
+      <div class="dropdown">
+        <a href="javascript:void(0)">Services ▾</a>
+        <div class="dropdown-content">
+          <a href="personal-bankruptcy.html">Personal Bankruptcy</a>
+          <a href="business-bankruptcy.html">Business Bankruptcy</a>
+        </div>
+      </div>
+      <a href="testimonials.html">Testimonials</a>
+      <a href="faq.html">FAQ</a>
+      <a href="contact.html">Contact</a>
+      <a href="pay-online.html" class="btn" style="margin-left:1rem; margin-top:0; padding:0.5rem 1rem;">Pay Online</a>
     </nav>
   </header>
 


### PR DESCRIPTION
## Summary
- Add dropdown navigation under Services linking to Personal and Business Bankruptcy pages
- Include About and Contact page links and apply navigation across all pages
## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689515d42f54832191559fe15e54c7e8