### PR TITLE
Use Cloudflare-hosted images

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,7 +14,7 @@
 <body>
   <header class="site-header">
     <a href="/" class="logo-link">
-      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
       <a href="about.html">About</a>
@@ -35,7 +35,7 @@
   <section class="bg-white" id="about">
     <h1 style="text-align:center;">About Us</h1>
     <div class="about-wrapper">
-      <img src="https://via.placeholder.com/320x400" alt="Robert A. Pohl - Bankruptcy Attorney" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/1ab4fdc6-aa8f-4845-1760-5d6bdbd1e300/public" alt="Robert A. Pohl - Bankruptcy Attorney" />
       <div class="about-text">
         <h2 style="text-align:left;">Robert A. Pohl – Bankruptcy Attorney</h2>
         <p>Robert A. Pohl is a seasoned bankruptcy attorney holding a J.D., LL.M. in Tax, and an MBA. Admitted in the U.S. Virgin Islands and multiple states, he has spent more than 25&nbsp;years helping individuals and businesses overcome debt.</p>

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -14,7 +14,7 @@
 <body>
   <header class="site-header">
     <a href="/" class="logo-link">
-      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
       <a href="about.html">About</a>

--- a/contact.html
+++ b/contact.html
@@ -14,7 +14,7 @@
 <body>
   <header class="site-header">
     <a href="/" class="logo-link">
-      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
       <a href="about.html">About</a>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -14,7 +14,7 @@
 <body>
   <header class="site-header">
     <a href="/" class="logo-link">
-      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
       <a href="about.html">About</a>

--- a/faq.html
+++ b/faq.html
@@ -14,7 +14,7 @@
 <body>
   <header class="site-header">
     <a href="/" class="logo-link">
-      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
       <a href="about.html">About</a>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 <body>
   <header class="site-header">
     <a href="/" class="logo-link">
-      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
       <a href="about.html">About</a>

--- a/pay-online.html
+++ b/pay-online.html
@@ -14,7 +14,7 @@
 <body>
   <header class="site-header">
     <a href="/" class="logo-link">
-      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
       <a href="about.html">About</a>

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -14,7 +14,7 @@
 <body>
   <header class="site-header">
     <a href="/" class="logo-link">
-      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
       <a href="about.html">About</a>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -14,7 +14,7 @@
 <body>
   <header class="site-header">
     <a href="/" class="logo-link">
-      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
       <a href="about.html">About</a>

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -14,7 +14,7 @@
 <body>
   <header class="site-header">
     <a href="/" class="logo-link">
-      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
       <a href="about.html">About</a>

--- a/styles.css
+++ b/styles.css
@@ -62,7 +62,7 @@ body {
   position: relative;
   height: 60vh;
   min-height: 420px;
-  background: url("https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/77a43069-ed54-403f-d367-7b5bd71ef000/public") center/cover no-repeat;
+  background: url("https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public") center/cover no-repeat;
   display: flex;
   align-items: center;
   padding: 0 1.25rem;

--- a/testimonials.html
+++ b/testimonials.html
@@ -14,7 +14,7 @@
 <body>
   <header class="site-header">
     <a href="/" class="logo-link">
-      <img src="https://imagedelivery.net/9748736d8674bad21f5e685fa96db7cd/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
     </a>
     <nav>
       <a href="about.html">About</a>


### PR DESCRIPTION
## Summary
- Swap all logo references to new Cloudflare account hash.
- Replace home-page hero background and about-page profile photo with Cloudflare hosted images.

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68951c3647148321bc3af8de94c0b46c