### PR TITLE
Add utility styles for midnight sections and contact form

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,47 @@ body {
 /* Background helpers */
 .bg-white { background: #fff; color: var(--vi-2); }
 .bg-gray  { background: var(--vi-gray); color: var(--vi-2); }
+.bg-midnight { background: var(--vi-2); color: #fff; }
+
+.section-title {
+  font-family: "Cinzel", serif;
+  font-size: 2rem;
+  font-weight: 400;
+  color: var(--vi-5);
+  text-align: center;
+  margin: 0 0 0.5rem;
+}
+
+.section-subtitle {
+  font-size: 1.125rem;
+  color: #fff;
+  text-align: center;
+  max-width: 700px;
+  margin: 0 auto 2rem;
+}
+
+.form-group { margin-bottom: 0.75rem; }
+
+.form-submit {
+  display: block;
+  width: 100%;
+  margin-top: 1rem;
+}
+
+.confidential-note {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--vi-5);
+  font-size: 0.875rem;
+}
+
+.map { margin-top: 1rem; }
+.map iframe {
+  width: 100%;
+  border: 0;
+  height: 250px;
+  border-radius: 4px;
+}
 
 /* Header */
 .site-header {


### PR DESCRIPTION
## Summary
- style `.bg-midnight` for dark sections with white text
- add typography utilities for `.section-title` and `.section-subtitle`
- add form and map helpers to match site palette

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689523a6ac0083219e5a32c6377d488a