### PR TITLE
Add hero sections to subpages

### DIFF
--- a/about.html
+++ b/about.html
@@ -31,9 +31,13 @@
       <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
     </nav>
   </header>
+  
+  <section class="hero hero-about">
+    <h1>About Us</h1>
+  </section>
 
   <section class="bg-white" id="about">
-    <h1 style="text-align:center;">About Us</h1>
+    <h2 style="text-align:center;">About Us</h2>
     <div class="about-wrapper">
       <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/1ab4fdc6-aa8f-4845-1760-5d6bdbd1e300/public" alt="Robert A. Pohl - Bankruptcy Attorney" />
       <div class="about-text">

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -31,10 +31,13 @@
       <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
     </nav>
   </header>
+  
+  <section class="hero hero-business">
+    <h1>Business Bankruptcy</h1>
+  </section>
 
   <section class="bg-white">
-    <h1>Business Bankruptcy</h1>
-    <p style="text-align:center; max-width:700px; margin:0 auto;">Chapter 11 &amp; Debt Relief for Businesses in the VI</p>
+    <h2 style="text-align:center; max-width:700px; margin:0 auto;">Chapter 11 &amp; Debt Relief for Businesses in the VI</h2>
   </section>
 
   <section class="bg-gray">

--- a/contact.html
+++ b/contact.html
@@ -31,9 +31,13 @@
       <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
     </nav>
   </header>
+  
+  <section class="hero hero-contact">
+    <h1>Contact Us</h1>
+  </section>
 
   <section class="bg-midnight">
-    <h1 class="section-title">Contact Us</h1>
+    <h2 class="section-title">Reach Out</h2>
     <p class="section-subtitle">We're here to help – reach out today.</p>
     <div class="contact-grid">
       <div>

--- a/faq.html
+++ b/faq.html
@@ -31,9 +31,13 @@
       <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
     </nav>
   </header>
+  
+  <section class="hero hero-faq">
+    <h1>Bankruptcy FAQ</h1>
+  </section>
 
   <section class="bg-white" id="faq">
-    <h1>Bankruptcy FAQ</h1>
+    <h2>Frequently Asked Questions</h2>
     <details>
       <summary>Will everyone know I filed bankruptcy?</summary>
       <p>For the most part, no. Bankruptcies are public records, but unless someone is specifically looking, your friends or employer won’t be automatically notified. However, notices do go to your creditors and co‑debtors.</p>

--- a/pay-online.html
+++ b/pay-online.html
@@ -31,9 +31,13 @@
       <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
     </nav>
   </header>
+  
+  <section class="hero hero-pay">
+    <h1>Pay Online</h1>
+  </section>
 
   <section>
-    <h1>Pay Online</h1>
+    <h2>Secure Payment Portal</h2>
     <p>Use our secure payment portal to pay your invoice or bankruptcy filing fee. Enter your name or case number to ensure proper credit of your payment.</p>
     <div style="margin-top:1.5rem;">
       <a href="https://secure.lawpay.com/pages/robert-pohl-law/vi-bankruptcy" class="btn" target="_blank" rel="noopener">Pay Now</a>

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -31,10 +31,13 @@
       <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
     </nav>
   </header>
+  
+  <section class="hero hero-personal">
+    <h1>Personal Bankruptcy</h1>
+  </section>
 
   <section class="bg-white">
-    <h1>Personal Bankruptcy</h1>
-    <p style="text-align:center; max-width:700px; margin:0 auto;">Chapter 7 &amp; Chapter 13 for Individuals and Families</p>
+    <h2 style="text-align:center; max-width:700px; margin:0 auto;">Chapter 7 &amp; Chapter 13 for Individuals and Families</h2>
   </section>
 
   <section class="bg-gray">

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -31,9 +31,13 @@
       <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
     </nav>
   </header>
+  
+  <section class="hero hero-ready">
+    <h1>Ready to File?</h1>
+  </section>
 
   <section class="bg-midnight">
-    <h1 class="section-title">Ready to File? Checklist</h1>
+    <h2 class="section-title">Checklist</h2>
     <p class="section-subtitle">Get organized and take the first steps toward a fresh start.</p>
   </section>
 

--- a/styles.css
+++ b/styles.css
@@ -118,6 +118,15 @@ body {
   line-height: 1.2;
 }
 
+.hero-about { background: var(--vi-1); }
+.hero-personal { background: var(--vi-2); }
+.hero-business { background: var(--vi-3); }
+.hero-testimonials { background: var(--vi-1); }
+.hero-faq { background: var(--vi-2); }
+.hero-contact { background: var(--vi-3); }
+.hero-pay { background: var(--vi-1); }
+.hero-ready { background: var(--vi-2); }
+
 /* Section base */
 section { padding: 3rem 1.25rem; }
 

--- a/testimonials.html
+++ b/testimonials.html
@@ -31,10 +31,13 @@
       <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
     </nav>
   </header>
+  
+  <section class="hero hero-testimonials">
+    <h1>Testimonials</h1>
+  </section>
 
   <section class="bg-white" id="testimonials">
-    <h1>Testimonials</h1>
-    <p class="subtitle">Hear from Our Clients</p>
+    <h2>Hear from Our Clients</h2>
     <div class="testimonials">
       <blockquote>
         <p><strong>I was drowning in debt and considering bankruptcy as a last resort. Robert Pohl treated me with respect and patience from day one.</strong> He answered all my questions and guided me through a Chapter&nbsp;7 bankruptcy that wiped out almost $50,000 of credit card and medical bills. I'm now debt-free and it feels like I can breathe again. I highly recommend Mr.&nbsp;Pohl to anyone in the Virgin Islands who needs help.</p>


### PR DESCRIPTION
## Summary
- Add hero banners to About, Personal Bankruptcy, Business Bankruptcy, Testimonials, FAQ, Contact, Pay Online, and Ready to File pages
- Centralize page-specific hero backgrounds in `styles.css`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895266567288321be0a814be20cce21