### PR TITLE
style: centralize footer link styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -63,7 +63,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 </body>
 </html>

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -76,7 +76,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -83,7 +83,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 
   <script>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -41,7 +41,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 </body>
 </html>

--- a/pay-online.html
+++ b/pay-online.html
@@ -45,7 +45,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 </body>
 </html>

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -82,7 +82,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 </body>
 </html>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -41,7 +41,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 </body>
 </html>

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -67,7 +67,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -258,3 +258,7 @@ footer {
   font-size: 0.875rem;
   text-align: center;
 }
+footer a {
+  color: #fff;
+  text-decoration: underline;
+}

--- a/testimonials.html
+++ b/testimonials.html
@@ -56,7 +56,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html" style="color:#fff; text-decoration:underline;">Pay Online</a> · <a href="privacy-policy.html" style="color:#fff; text-decoration:underline;">Privacy Policy</a> · <a href="disclaimer.html" style="color:#fff; text-decoration:underline;">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add global CSS rule to style footer links with white, underlined text
- Remove inline style attributes from footer links so they inherit the global rule

## Testing
- `npx prettier --check .` *(fails: Code style issues found in 13 files)*

------
https://chatgpt.com/codex/tasks/task_e_689529152808832199990978258d42db