### PR TITLE
style: polish about page layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -37,11 +37,11 @@
   </section>
 
   <section class="bg-white" id="about">
-    <h2 style="text-align:center;">About Us</h2>
+    <h2 class="section-title">About Us</h2>
     <div class="about-wrapper">
       <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/1ab4fdc6-aa8f-4845-1760-5d6bdbd1e300/public" alt="Robert A. Pohl - Bankruptcy Attorney" />
       <div class="about-text">
-        <h2 style="text-align:left;">Robert A. Pohl – Bankruptcy Attorney</h2>
+        <h3 class="about-heading">Robert A. Pohl – Bankruptcy Attorney</h3>
         <p>Robert A. Pohl is a seasoned bankruptcy attorney holding a J.D., LL.M. in Tax, and an MBA. Admitted in the U.S. Virgin Islands and multiple states, he has spent more than 25&nbsp;years helping individuals and businesses overcome debt.</p>
         <p>"I believe in treating every client like family," Robert says. His philosophy centers on delivering straightforward advice with compassion and confidentiality.</p>
       </div>
@@ -49,7 +49,7 @@
   </section>
 
   <section class="bg-gray">
-    <h2>The Pohl Approach</h2>
+    <h2 class="section-title">The Pohl Approach</h2>
     <ul class="why-list">
       <li><strong>Personalized Attention</strong> – each case receives tailored strategies.</li>
       <li><strong>Straightforward Advice</strong> – clear guidance without legal jargon.</li>

--- a/styles.css
+++ b/styles.css
@@ -139,6 +139,36 @@ h2 {
   text-align: center;
 }
 
+/* About */
+.about-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+.about-wrapper img {
+  width: 100%;
+  max-width: 320px;
+  border-radius: 8px;
+}
+.about-text { text-align: center; }
+.about-heading {
+  font-family: "Merriweather", serif;
+  font-size: 1.5rem;
+  color: var(--vi-1);
+  margin-top: 0;
+}
+@media (min-width: 768px) {
+  .about-wrapper {
+    flex-direction: row;
+    align-items: flex-start;
+    text-align: left;
+  }
+  .about-text { text-align: left; }
+}
+
 .services {
   display: grid;
   gap: 2rem;


### PR DESCRIPTION
## Summary
- Refine About Us section with class-based headings and improved semantics
- Introduce responsive flex layout and styling for attorney photo and text
- Apply consistent section title styling across About page

## Testing
- `npx --yes htmlhint about.html` *(fails: 403 Forbidden)*
- `tidy -qe about.html` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68952a7dab608321b66ccdf3d08bc754