### PR TITLE
Refine About page layout and styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -37,11 +37,11 @@
   </section>
 
   <section class="bg-white" id="about">
-    <h2 style="text-align:center;">About Us</h2>
+    <h2 class="section-title">About Us</h2>
     <div class="about-wrapper">
-      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/1ab4fdc6-aa8f-4845-1760-5d6bdbd1e300/public" alt="Robert A. Pohl - Bankruptcy Attorney" />
+      <img class="about-photo" src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/1ab4fdc6-aa8f-4845-1760-5d6bdbd1e300/public" alt="Robert A. Pohl - Bankruptcy Attorney" />
       <div class="about-text">
-        <h2 style="text-align:left;">Robert A. Pohl – Bankruptcy Attorney</h2>
+        <h3 class="about-heading">Robert A. Pohl – Bankruptcy Attorney</h3>
         <p>Robert A. Pohl is a seasoned bankruptcy attorney holding a J.D., LL.M. in Tax, and an MBA. Admitted in the U.S. Virgin Islands and multiple states, he has spent more than 25&nbsp;years helping individuals and businesses overcome debt.</p>
         <p>"I believe in treating every client like family," Robert says. His philosophy centers on delivering straightforward advice with compassion and confidentiality.</p>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -179,6 +179,32 @@ h2 {
   color: var(--vi-gold);
 }
 
+/* About */
+.about-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+.about-photo {
+  width: 100%;
+  max-width: 240px;
+  border-radius: 6px;
+}
+.about-text { text-align: left; }
+.about-heading {
+  font-family: "Merriweather", serif;
+  font-size: 1.5rem;
+  color: var(--vi-1);
+  margin-top: 0;
+}
+@media (min-width: 768px) {
+  .about-wrapper { flex-direction: row; align-items: flex-start; }
+  .about-text { flex: 1; }
+}
+
 /* Testimonials */
 .testimonials {
   max-width: 900px;


### PR DESCRIPTION
## Summary
- Replaced inline about-page heading styles with reusable classes and semantic tags
- Added dedicated about-page flexbox layout and image styling for a polished, responsive presentation

## Testing
- `npx htmlhint about.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68952a7dab608321b66ccdf3d08bc754