### PR TITLE
Tidy contact links and shorten non-home heroes

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -49,7 +49,7 @@
           St. John: By appointment
         </p>
         <p><strong>Hours:</strong> Mon–Fri 9am–5pm AST (and by appointment)</p>
-        <p><a href="ready-to-file.html" style="color:#fff; text-decoration:underline;">View our "Ready to File" checklist</a> to prepare your paperwork before your appointment.</p>
+        <p><a href="ready-to-file.html">View our "Ready to File" checklist</a> to prepare your paperwork before your appointment.</p>
         <div class="map">
           <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3793.381593432963!2d-64.91999928459224!3d18.33299857801429!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x8c0510adb88ae201%3A0x9b9d054b022b35c6!2s5316%20Yacht%20Haven%20Grande%2C%20St%20Thomas%2C%20VI%2000802!5e0!3m2!1sen!2sus!4v1712500000000!5m2!1sen!2sus" allowfullscreen="" loading="lazy"></iframe>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -22,6 +22,15 @@ body {
 .bg-gray  { background: var(--vi-gray); color: var(--vi-2); }
 .bg-midnight { background: var(--vi-2); color: #fff; }
 
+.bg-midnight a {
+  color: #fff;
+  text-decoration: underline;
+}
+
+.bg-midnight a:hover {
+  color: var(--vi-5);
+}
+
 .section-title {
   font-family: "Cinzel", serif;
   font-size: 2rem;
@@ -126,6 +135,18 @@ body {
 .hero-contact { background: var(--vi-3); }
 .hero-pay { background: var(--vi-1); }
 .hero-ready { background: var(--vi-2); }
+
+.hero.hero-about,
+.hero.hero-personal,
+.hero.hero-business,
+.hero.hero-testimonials,
+.hero.hero-faq,
+.hero.hero-contact,
+.hero.hero-pay,
+.hero.hero-ready {
+  height: 45vh;
+  min-height: 300px;
+}
 
 /* Section base */
 section { padding: 3rem 1.25rem; }


### PR DESCRIPTION
## Summary
- Style contact page links in white with a light hover accent
- Shorten hero banners for all pages except the homepage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68953384940883218b55d35dddc77c37