### PR TITLE
Add hero taglines and intros across site pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -33,7 +33,17 @@
   </header>
   
   <section class="hero hero-about">
-    <h1>About Us</h1>
+    <div class="hero-content">
+      <h1>About Us</h1>
+      <p>Experienced guidance from a firm that treats every client like family.</p>
+    </div>
+  </section>
+
+  <section class="bg-white">
+    <div class="intro-text">
+      <h2>Your Neighbor in Financial Recovery</h2>
+      <p>Learn more about our experience and client‑focused approach.</p>
+    </div>
   </section>
 
   <section class="bg-white" id="about">

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -33,11 +33,17 @@
   </header>
   
   <section class="hero hero-business">
-    <h1>Business Bankruptcy</h1>
+    <div class="hero-content">
+      <h1>Business Bankruptcy</h1>
+      <p>Strategic options to help your company regroup and move forward.</p>
+    </div>
   </section>
 
   <section class="bg-white">
-    <h2 style="text-align:center; max-width:700px; margin:0 auto;">Chapter 11 &amp; Debt Relief for Businesses in the VI</h2>
+    <div class="intro-text">
+      <h2>Chapter 11 &amp; Debt Relief for Businesses in the VI</h2>
+      <p>We guide Virgin Islands businesses through reorganization, liquidation, and alternative workouts.</p>
+    </div>
   </section>
 
   <section class="bg-gray">

--- a/contact.html
+++ b/contact.html
@@ -33,7 +33,17 @@
   </header>
   
   <section class="hero hero-contact">
-    <h1>Contact Us</h1>
+    <div class="hero-content">
+      <h1>Contact Us</h1>
+      <p>Friendly, confidential guidance is just a call or message away.</p>
+    </div>
+  </section>
+
+  <section class="bg-white">
+    <div class="intro-text">
+      <h2>We're Ready to Listen</h2>
+      <p>Reach out for a free, no-pressure consultation.</p>
+    </div>
   </section>
 
   <section class="bg-midnight">

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -32,8 +32,21 @@
     </nav>
   </header>
 
+  <section class="hero hero-disclaimer">
+    <div class="hero-content">
+      <h1>Disclaimer</h1>
+      <p>Understand the limits of using this site and contacting our firm.</p>
+    </div>
+  </section>
+
   <section class="bg-white">
-    <h1 style="text-align:center;">Disclaimer</h1>
+    <div class="intro-text">
+      <h2>Please Read Before Proceeding</h2>
+      <p>The details below outline important legal notices about this website and our communications.</p>
+    </div>
+  </section>
+
+  <section class="bg-white">
     <p>The information on this website is provided for general informational purposes only and should not be construed as legal advice on any subject matter. You should not act or refrain from acting on the basis of any content included in this site without seeking appropriate legal or other professional advice.</p>
     <p>Use of this website or contacting the Law Office of Robert Pohl through this site does not create an attorney-client relationship. Please do not send confidential or time-sensitive information until such a relationship has been established.</p>
     <p>While we strive to keep the information on this site current, we make no guarantees about the accuracy or completeness of the information and disclaim liability for errors or omissions. Links to external websites are provided for convenience and do not imply endorsement.</p>

--- a/faq.html
+++ b/faq.html
@@ -33,7 +33,17 @@
   </header>
   
   <section class="hero hero-faq">
-    <h1>Bankruptcy FAQ</h1>
+    <div class="hero-content">
+      <h1>Bankruptcy FAQ</h1>
+      <p>Quick answers to common questions about the process.</p>
+    </div>
+  </section>
+
+  <section class="bg-white">
+    <div class="intro-text">
+      <h2>Common Concerns, Clear Answers</h2>
+      <p>Explore these FAQs to better understand how bankruptcy may help you.</p>
+    </div>
   </section>
 
   <section class="bg-white" id="faq">

--- a/pay-online.html
+++ b/pay-online.html
@@ -33,14 +33,19 @@
   </header>
   
   <section class="hero hero-pay">
-    <h1>Pay Online</h1>
+    <div class="hero-content">
+      <h1>Pay Online</h1>
+      <p>Convenient, secure payment options for our clients.</p>
+    </div>
   </section>
 
-  <section>
-    <h2>Secure Payment Portal</h2>
-    <p>Use our secure payment portal to pay your invoice or bankruptcy filing fee. Enter your name or case number to ensure proper credit of your payment.</p>
-    <div style="margin-top:1.5rem;">
-      <a href="https://secure.lawpay.com/pages/robert-pohl-law/vi-bankruptcy" class="btn" target="_blank" rel="noopener">Pay Now</a>
+  <section class="bg-white">
+    <div class="intro-text">
+      <h2>Secure Payment Portal</h2>
+      <p>Use our secure payment portal to pay your invoice or bankruptcy filing fee. Enter your name or case number to ensure proper credit of your payment.</p>
+      <div style="margin-top:1.5rem;">
+        <a href="https://secure.lawpay.com/pages/robert-pohl-law/vi-bankruptcy" class="btn" target="_blank" rel="noopener">Pay Now</a>
+      </div>
     </div>
   </section>
 

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -1,88 +1,166 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Personal Bankruptcy | VI Bankruptcy</title>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Personal Bankruptcy | VI Bankruptcy</title>
 
-  <!-- Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css" />
-</head>
-<body>
-  <header class="site-header">
-    <a href="index.html" class="logo-link">
-      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
-    </a>
-    <nav>
-      <a href="about.html">About</a>
-      <div class="dropdown">
-        <a href="javascript:void(0)">Services ▾</a>
-        <div class="dropdown-content">
-          <a href="personal-bankruptcy.html">Personal Bankruptcy</a>
-          <a href="business-bankruptcy.html">Business Bankruptcy</a>
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a href="index.html" class="logo-link">
+        <img
+          src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public"
+          alt="viBankruptcy logo"
+        />
+      </a>
+      <nav>
+        <a href="about.html">About</a>
+        <div class="dropdown">
+          <a href="javascript:void(0)">Services ▾</a>
+          <div class="dropdown-content">
+            <a href="personal-bankruptcy.html">Personal Bankruptcy</a>
+            <a href="business-bankruptcy.html">Business Bankruptcy</a>
+          </div>
         </div>
+        <a href="testimonials.html">Testimonials</a>
+        <a href="faq.html">FAQ</a>
+        <a href="contact.html">Contact</a>
+        <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
+      </nav>
+    </header>
+
+    <section class="hero hero-personal">
+      <div class="hero-content">
+        <h1>Personal Bankruptcy</h1>
+        <p>Confident, local guidance for a fresh financial start.</p>
       </div>
-      <a href="testimonials.html">Testimonials</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-      <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
-    </nav>
-  </header>
-  
-  <section class="hero hero-personal">
-    <h1>Personal Bankruptcy</h1>
-  </section>
+    </section>
 
-  <section class="bg-white">
-    <h2 style="text-align:center; max-width:700px; margin:0 auto;">Chapter 7 &amp; Chapter 13 for Individuals and Families</h2>
-  </section>
+    <section class="bg-white">
+      <div class="intro-text">
+        <h2>Chapter 7 &amp; Chapter 13 for Individuals and Families</h2>
+        <p>
+          Debt can feel overwhelming, but bankruptcy law was designed to give
+          honest people a second chance. The Law Office of Robert Pohl helps
+          Virgin Islanders use federal protections to erase or reorganize debt
+          while keeping the assets that matter most.
+        </p>
+      </div>
+    </section>
 
-  <section class="bg-gray">
-    <h3><span style="font-size:2rem;">🛡️</span>Chapter 7 Bankruptcy</h3>
-    <ul class="chapter-list">
-      <li>Designed for those who cannot afford to repay debts.</li>
-      <li>Wipes out (discharges) most unsecured debts like credit cards, medical bills.</li>
-      <li>Typically completed in ~4 months.</li>
-      <li>Qualify via a "Means Test" (income threshold).</li>
-      <li><em>Most filers keep their essentials (home equity, car, retirement) thanks to exemptions.</em></li>
-    </ul>
-  </section>
+    <section class="bg-gray">
+      <h3><span style="font-size: 2rem">🛡️</span>Chapter 7 Bankruptcy</h3>
+      <ul class="chapter-list">
+        <li>Designed for those who cannot afford to repay debts.</li>
+        <li>
+          Wipes out (discharges) most unsecured debts like credit cards, medical
+          bills.
+        </li>
+        <li>Typically completed in ~4 months.</li>
+        <li>Qualify via a "Means Test" (income threshold).</li>
+        <li>
+          <em
+            >Most filers keep their essentials (home equity, car, retirement)
+            thanks to exemptions.</em
+          >
+        </li>
+      </ul>
+    </section>
 
-  <section class="bg-white">
-    <h3><span style="font-size:2rem;">🏠</span>Chapter 13 Bankruptcy</h3>
-    <ul class="chapter-list">
-      <li>A repayment plan to catch up on debts over 3-5 years.</li>
-      <li>Ideal for stopping foreclosure or spread out back payments on mortgages, car loans, etc.</li>
-      <li>You make affordable monthly payments to a trustee who pays your creditors.</li>
-      <li>Keep your property while making payments.</li>
-      <li>Must have regular income within debt limits.</li>
-    </ul>
-  </section>
+    <section class="bg-white">
+      <h3><span style="font-size: 2rem">🏠</span>Chapter 13 Bankruptcy</h3>
+      <ul class="chapter-list">
+        <li>A repayment plan to catch up on debts over 3-5 years.</li>
+        <li>
+          Ideal for stopping foreclosure or spread out back payments on
+          mortgages, car loans, etc.
+        </li>
+        <li>
+          You make affordable monthly payments to a trustee who pays your
+          creditors.
+        </li>
+        <li>Keep your property while making payments.</li>
+        <li>Must have regular income within debt limits.</li>
+      </ul>
+    </section>
 
-  <section class="bg-gray">
-    <h2>Common Questions</h2>
-    <div class="faq">
-      <p><strong>Q: Will I lose my house or car in bankruptcy?</strong></p>
-      <p>A: <strong>Not likely.</strong> Both Chapter 7 and 13 have provisions to protect your home/car (either via exemptions or the repayment plan). We'll explain based on your case.</p>
+    <section class="bg-gray">
+      <h3><span style="font-size: 2rem">📈</span>Why Filing May Help</h3>
+      <ul class="chapter-list">
+        <li>Stop creditor harassment and wage garnishments.</li>
+        <li>Protect homes, vehicles, and bank accounts.</li>
+        <li>Rebuild credit sooner than staying in default.</li>
+        <li>Gain peace of mind with a clear legal plan.</li>
+      </ul>
+    </section>
 
-      <p><strong>Q: Can bankruptcy help with student loans or tax debts?</strong></p>
-      <p>A: Student loans are generally not dischargeable (except in rare hardship cases). Some tax debts can be discharged if old enough; others can be included in a Chapter 13 plan.</p>
+    <section class="bg-white">
+      <h3><span style="font-size: 2rem">🤝</span>Why Work With Our Firm</h3>
+      <ul class="chapter-list">
+        <li>
+          More than two decades serving individuals and families in the Virgin
+          Islands.
+        </li>
+        <li>Hands-on help from the first consultation through discharge.</li>
+        <li>Transparent fees and flexible payment options.</li>
+      </ul>
+    </section>
 
-      <p><strong>Q: How will bankruptcy affect my credit?</strong></p>
-      <p>A: It will be noted on your credit report (10 years for Chapter 7, 7 years for 13). However, many clients see their score start to improve within a year because they're no longer weighed down by delinquent accounts.</p>
-    </div>
-  </section>
+    <section class="bg-gray">
+      <h2>Common Questions</h2>
+      <div class="faq">
+        <p><strong>Q: Will I lose my house or car in bankruptcy?</strong></p>
+        <p>
+          A: <strong>Not likely.</strong> Both Chapter 7 and 13 have provisions
+          to protect your home/car (either via exemptions or the repayment
+          plan). We'll explain based on your case.
+        </p>
 
-  <section class="cta bg-white">
-    <p>Bankruptcy is a legal tool to rebuild your life – not the end of the road. If you're unsure which option fits you, <strong>schedule a free consultation</strong> and we'll guide you through.</p>
-    <a href="contact.html" class="btn">Free Consultation</a>
-  </section>
+        <p>
+          <strong
+            >Q: Can bankruptcy help with student loans or tax debts?</strong
+          >
+        </p>
+        <p>
+          A: Student loans are generally not dischargeable (except in rare
+          hardship cases). Some tax debts can be discharged if old enough;
+          others can be included in a Chapter 13 plan.
+        </p>
 
-  <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
-  </footer>
-</body>
+        <p><strong>Q: How will bankruptcy affect my credit?</strong></p>
+        <p>
+          A: It will be noted on your credit report (10 years for Chapter 7, 7
+          years for 13). However, many clients see their score start to improve
+          within a year because they're no longer weighed down by delinquent
+          accounts.
+        </p>
+      </div>
+    </section>
+
+    <section class="cta bg-white">
+      <p>
+        Bankruptcy is a legal tool to rebuild your life – not the end of the
+        road. If you're unsure which option fits you,
+        <strong>schedule a free consultation</strong> and we'll guide you
+        through.
+      </p>
+      <a href="contact.html" class="btn">Free Consultation</a>
+    </section>
+
+    <footer>
+      &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl ·
+      <a href="pay-online.html">Pay Online</a> ·
+      <a href="privacy-policy.html">Privacy Policy</a> ·
+      <a href="disclaimer.html">Disclaimer</a>
+    </footer>
+  </body>
 </html>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -32,8 +32,21 @@
     </nav>
   </header>
 
+  <section class="hero hero-privacy">
+    <div class="hero-content">
+      <h1>Privacy Policy</h1>
+      <p>How we collect, use, and protect your information.</p>
+    </div>
+  </section>
+
   <section class="bg-white">
-    <h1 style="text-align:center;">Privacy Policy</h1>
+    <div class="intro-text">
+      <h2>Your Privacy Matters</h2>
+      <p>We respect your personal data and outline our practices below.</p>
+    </div>
+  </section>
+
+  <section class="bg-white">
     <p>The Law Office of Robert Pohl respects your privacy. We collect information that you voluntarily provide, such as through contact forms, emails, or phone calls. This information is used solely to respond to your inquiries and to provide legal services. We do not sell or share personal information with third parties.</p>
     <p>Basic website analytics may be used to understand visitor trends, but these tools do not identify individual users. Submitting information through this site does not create an attorney-client relationship. Please do not send confidential information until an attorney-client relationship has been established.</p>
     <p>We may update this policy from time to time. Continued use of the site constitutes acceptance of any changes. For questions about this policy, please contact us directly.</p>

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -33,12 +33,17 @@
   </header>
   
   <section class="hero hero-ready">
-    <h1>Ready to File?</h1>
+    <div class="hero-content">
+      <h1>Ready to File?</h1>
+      <p>Gather the essentials for a smoother bankruptcy process.</p>
+    </div>
   </section>
 
-  <section class="bg-midnight">
-    <h2 class="section-title">Checklist</h2>
-    <p class="section-subtitle">Get organized and take the first steps toward a fresh start.</p>
+  <section class="bg-white">
+    <div class="intro-text">
+      <h2>Checklist</h2>
+      <p>Get organized and take the first steps toward a fresh start.</p>
+    </div>
   </section>
 
   <section class="bg-gray">

--- a/styles.css
+++ b/styles.css
@@ -1,12 +1,12 @@
 :root {
-  --vi-1: #1B3940; /* Deep Teal */
+  --vi-1: #1b3940; /* Deep Teal */
   --vi-2: #132326; /* Midnight */
-  --vi-3: #59453E; /* Brown‑Gray */
-  --vi-4: #A68D85; /* Taupe */
-  --vi-5: #D9C6BF; /* Shell */
-  --vi-gold: #BD9E07; /* accent line */
-  --vi-nav: #1C1F19; /* navigation bar */
-  --vi-gray: #F4F4F4; /* utility gray */
+  --vi-3: #59453e; /* Brown‑Gray */
+  --vi-4: #a68d85; /* Taupe */
+  --vi-5: #d9c6bf; /* Shell */
+  --vi-gold: #bd9e07; /* accent line */
+  --vi-nav: #1c1f19; /* navigation bar */
+  --vi-gray: #f4f4f4; /* utility gray */
 }
 
 body {
@@ -18,9 +18,18 @@ body {
 }
 
 /* Background helpers */
-.bg-white { background: #fff; color: var(--vi-2); }
-.bg-gray  { background: var(--vi-gray); color: var(--vi-2); }
-.bg-midnight { background: var(--vi-2); color: #fff; }
+.bg-white {
+  background: #fff;
+  color: var(--vi-2);
+}
+.bg-gray {
+  background: var(--vi-gray);
+  color: var(--vi-2);
+}
+.bg-midnight {
+  background: var(--vi-2);
+  color: #fff;
+}
 
 .bg-midnight a {
   color: #fff;
@@ -48,7 +57,24 @@ body {
   margin: 0 auto 2rem;
 }
 
-.form-group { margin-bottom: 0.75rem; }
+.intro-text {
+  text-align: center;
+  max-width: 700px;
+  margin: 0 auto 2rem;
+  padding: 0 1rem;
+}
+
+.intro-text h2 {
+  margin-bottom: 0.5rem;
+}
+
+.intro-text p {
+  margin: 0;
+}
+
+.form-group {
+  margin-bottom: 0.75rem;
+}
 
 .form-submit {
   display: block;
@@ -63,7 +89,9 @@ body {
   font-size: 0.875rem;
 }
 
-.map { margin-top: 1rem; }
+.map {
+  margin-top: 1rem;
+}
 .map iframe {
   width: 100%;
   border: 0;
@@ -87,8 +115,13 @@ body {
   margin-left: 1rem;
   font-weight: 600;
 }
-.site-header nav a:hover { text-decoration: underline; }
-.site-header nav .dropdown { position: relative; display: inline-block; }
+.site-header nav a:hover {
+  text-decoration: underline;
+}
+.site-header nav .dropdown {
+  position: relative;
+  display: inline-block;
+}
 .site-header nav .dropdown-content {
   display: none;
   position: absolute;
@@ -104,15 +137,21 @@ body {
   margin: 0;
   padding: 0.5rem 1rem;
 }
-.site-header nav .dropdown:hover .dropdown-content { display: block; }
-.logo-link img { height: 48px; width: auto; }
+.site-header nav .dropdown:hover .dropdown-content {
+  display: block;
+}
+.logo-link img {
+  height: 48px;
+  width: auto;
+}
 
 /* Hero */
 .hero {
   position: relative;
   height: 60vh;
   min-height: 420px;
-  background: url("https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/7281805b-ff6f-4d66-ade8-d8c4bcc2d500/public") center/cover no-repeat;
+  background: url("https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/7281805b-ff6f-4d66-ade8-d8c4bcc2d500/public")
+    center/cover no-repeat;
   display: flex;
   align-items: center;
   padding: 0 1.25rem;
@@ -121,20 +160,54 @@ body {
   font-family: "Cinzel", serif;
   font-size: clamp(1.75rem, 4vw + 0.5rem, 3rem);
   font-weight: 400;
-  color: #C8B27F;
+  color: #c8b27f;
   margin: 0;
   text-transform: uppercase;
   line-height: 1.2;
 }
 
-.hero-about { background: var(--vi-1); }
-.hero-personal { background: var(--vi-2); }
-.hero-business { background: var(--vi-3); }
-.hero-testimonials { background: var(--vi-1); }
-.hero-faq { background: var(--vi-2); }
-.hero-contact { background: var(--vi-3); }
-.hero-pay { background: var(--vi-1); }
-.hero-ready { background: var(--vi-2); }
+.hero-content {
+  max-width: 700px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.hero-content p {
+  margin-top: 0.5rem;
+  font-size: 1.125rem;
+  color: #fff;
+}
+
+.hero-about {
+  background: var(--vi-1);
+}
+.hero-personal {
+  background: var(--vi-2);
+}
+.hero-business {
+  background: var(--vi-3);
+}
+.hero-testimonials {
+  background: var(--vi-1);
+}
+.hero-faq {
+  background: var(--vi-2);
+}
+.hero-contact {
+  background: var(--vi-3);
+}
+.hero-pay {
+  background: var(--vi-1);
+}
+.hero-ready {
+  background: var(--vi-2);
+}
+.hero-privacy {
+  background: var(--vi-3);
+}
+.hero-disclaimer {
+  background: var(--vi-2);
+}
 
 .hero.hero-about,
 .hero.hero-personal,
@@ -143,13 +216,17 @@ body {
 .hero.hero-faq,
 .hero.hero-contact,
 .hero.hero-pay,
-.hero.hero-ready {
+.hero.hero-ready,
+.hero.hero-privacy,
+.hero.hero-disclaimer {
   height: 45vh;
   min-height: 300px;
 }
 
 /* Section base */
-section { padding: 3rem 1.25rem; }
+section {
+  padding: 3rem 1.25rem;
+}
 
 h2 {
   font-family: "Merriweather", serif;
@@ -174,7 +251,9 @@ h2 {
   max-width: 320px;
   border-radius: 8px;
 }
-.about-text { text-align: center; }
+.about-text {
+  text-align: center;
+}
 .about-heading {
   font-family: "Merriweather", serif;
   font-size: 1.5rem;
@@ -187,7 +266,9 @@ h2 {
     align-items: flex-start;
     text-align: left;
   }
-  .about-text { text-align: left; }
+  .about-text {
+    text-align: left;
+  }
 }
 
 .services {
@@ -201,7 +282,7 @@ h2 {
   background: #fff;
   padding: 1.5rem;
   border-radius: 6px;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
   color: var(--vi-2);
 }
 .service-card h3 {
@@ -244,7 +325,9 @@ h2 {
   max-width: 240px;
   border-radius: 6px;
 }
-.about-text { text-align: left; }
+.about-text {
+  text-align: left;
+}
 .about-heading {
   font-family: "Merriweather", serif;
   font-size: 1.5rem;
@@ -252,8 +335,13 @@ h2 {
   margin-top: 0;
 }
 @media (min-width: 768px) {
-  .about-wrapper { flex-direction: row; align-items: flex-start; }
-  .about-text { flex: 1; }
+  .about-wrapper {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+  .about-text {
+    flex: 1;
+  }
 }
 
 /* Testimonials */
@@ -263,8 +351,14 @@ h2 {
   display: grid;
   gap: 1.5rem;
 }
-.more-link { text-align: center; grid-column: 1 / -1; }
-.more-link a { color: var(--vi-1); text-decoration: underline; }
+.more-link {
+  text-align: center;
+  grid-column: 1 / -1;
+}
+.more-link a {
+  color: var(--vi-1);
+  text-decoration: underline;
+}
 blockquote {
   position: relative;
   margin: 0;
@@ -274,7 +368,7 @@ blockquote {
   font-style: italic;
   color: #fff;
   border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 blockquote::before {
   content: "\201C";
@@ -294,7 +388,9 @@ blockquote cite {
 }
 
 /* CTA */
-.cta { text-align: center; }
+.cta {
+  text-align: center;
+}
 .btn {
   display: inline-block;
   background: var(--vi-1);
@@ -321,15 +417,22 @@ blockquote cite {
   margin: 0 auto;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
-.contact-grid label { display: block; margin-bottom: 0.25rem; font-weight: 600; }
-.contact-grid input, .contact-grid textarea {
+.contact-grid label {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-weight: 600;
+}
+.contact-grid input,
+.contact-grid textarea {
   width: 100%;
   padding: 0.5rem;
   border: 1px solid var(--vi-4);
   border-radius: 4px;
   font-family: inherit;
 }
-.contact-grid textarea { min-height: 120px; }
+.contact-grid textarea {
+  min-height: 120px;
+}
 
 /* Footer */
 footer {
@@ -353,7 +456,9 @@ footer a {
   border-bottom: 1px solid var(--vi-4);
   padding: 1rem 0;
 }
-.faq-list details:last-of-type { border-bottom: none; }
+.faq-list details:last-of-type {
+  border-bottom: none;
+}
 .faq-list summary {
   font-family: "Merriweather", serif;
   font-weight: 600;
@@ -362,7 +467,9 @@ footer a {
   position: relative;
   padding-right: 1.5rem;
 }
-.faq-list summary::-webkit-details-marker { display: none; }
+.faq-list summary::-webkit-details-marker {
+  display: none;
+}
 .faq-list summary::after {
   content: "+";
   position: absolute;
@@ -370,8 +477,12 @@ footer a {
   top: 0;
   color: var(--vi-gold);
 }
-.faq-list details[open] summary::after { content: "-"; }
-.faq-list p { margin: 0.5rem 0 0; }
+.faq-list details[open] summary::after {
+  content: "-";
+}
+.faq-list p {
+  margin: 0.5rem 0 0;
+}
 .testimonial-intro {
   text-align: center;
   max-width: 700px;

--- a/testimonials.html
+++ b/testimonials.html
@@ -33,7 +33,17 @@
   </header>
   
   <section class="hero hero-testimonials">
-    <h1>Testimonials</h1>
+    <div class="hero-content">
+      <h1>Testimonials</h1>
+      <p>Real stories from clients we’ve guided toward relief.</p>
+    </div>
+  </section>
+
+  <section class="bg-white">
+    <div class="intro-text">
+      <h2>Real Stories of Relief</h2>
+      <p>See how we’ve helped neighbors across the Virgin Islands find financial peace.</p>
+    </div>
   </section>
 
   <section class="bg-white" id="testimonials">


### PR DESCRIPTION
## Summary
- Introduce hero sections with supportive taglines and intro copy to all non-index pages
- Extend stylesheet with hero-privacy and hero-disclaimer variants

## Testing
- `npx prettier --check about.html business-bankruptcy.html contact.html disclaimer.html faq.html pay-online.html privacy-policy.html ready-to-file.html testimonials.html personal-bankruptcy.html styles.css` *(fails: npm error code E403)*

------
https://chatgpt.com/codex/tasks/task_e_689534f04eb08321ba3742551ddd4a93