### PR TITLE
Add tagline and intro to hero sections across pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -33,7 +33,11 @@
   </header>
   
   <section class="hero hero-about">
-    <h1>About Us</h1>
+    <div class="hero-content">
+      <h1>About Us</h1>
+      <p>Discover the experience behind our guidance.</p>
+      <p>Learn about Robert Pohl and our commitment to helping Virgin Islanders regain financial freedom.</p>
+    </div>
   </section>
 
   <section class="bg-white" id="about">

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -33,11 +33,11 @@
   </header>
   
   <section class="hero hero-business">
-    <h1>Business Bankruptcy</h1>
-  </section>
-
-  <section class="bg-white">
-    <h2 style="text-align:center; max-width:700px; margin:0 auto;">Chapter 11 &amp; Debt Relief for Businesses in the VI</h2>
+    <div class="hero-content">
+      <h1>Business Bankruptcy</h1>
+      <p>Strategic solutions for struggling companies.</p>
+      <p>Explore how Chapter&nbsp;11, Subchapter&nbsp;V, or liquidation can help your business move forward.</p>
+    </div>
   </section>
 
   <section class="bg-gray">

--- a/contact.html
+++ b/contact.html
@@ -33,12 +33,15 @@
   </header>
   
   <section class="hero hero-contact">
-    <h1>Contact Us</h1>
+    <div class="hero-content">
+      <h1>Contact Us</h1>
+      <p>We're ready to listen.</p>
+      <p>Reach out today to discuss your situation with a confidential consultation.</p>
+    </div>
   </section>
 
   <section class="bg-midnight">
     <h2 class="section-title">Reach Out</h2>
-    <p class="section-subtitle">We're here to help – reach out today.</p>
     <div class="contact-grid">
       <div>
         <p><strong>Phone:</strong> <a href="tel:8886764598">888-676-4598</a></p>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -32,8 +32,15 @@
     </nav>
   </header>
 
+  <section class="hero hero-pay">
+    <div class="hero-content">
+      <h1>Disclaimer</h1>
+      <p>Important information about this website.</p>
+      <p>Understand the limits of online legal information and how to formally establish an attorney-client relationship.</p>
+    </div>
+  </section>
+
   <section class="bg-white">
-    <h1 style="text-align:center;">Disclaimer</h1>
     <p>The information on this website is provided for general informational purposes only and should not be construed as legal advice on any subject matter. You should not act or refrain from acting on the basis of any content included in this site without seeking appropriate legal or other professional advice.</p>
     <p>Use of this website or contacting the Law Office of Robert Pohl through this site does not create an attorney-client relationship. Please do not send confidential or time-sensitive information until such a relationship has been established.</p>
     <p>While we strive to keep the information on this site current, we make no guarantees about the accuracy or completeness of the information and disclaim liability for errors or omissions. Links to external websites are provided for convenience and do not imply endorsement.</p>

--- a/faq.html
+++ b/faq.html
@@ -33,7 +33,11 @@
   </header>
   
   <section class="hero hero-faq">
-    <h1>Bankruptcy FAQ</h1>
+    <div class="hero-content">
+      <h1>Bankruptcy FAQ</h1>
+      <p>Answers to common bankruptcy questions.</p>
+      <p>Get clarity on the process and what to expect when filing in the Virgin Islands.</p>
+    </div>
   </section>
 
   <section class="bg-white" id="faq">

--- a/pay-online.html
+++ b/pay-online.html
@@ -33,7 +33,11 @@
   </header>
   
   <section class="hero hero-pay">
-    <h1>Pay Online</h1>
+    <div class="hero-content">
+      <h1>Pay Online</h1>
+      <p>Convenient and secure payments.</p>
+      <p>Use our trusted portal to pay your invoice or filing fee anytime.</p>
+    </div>
   </section>
 
   <section>

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -42,6 +42,7 @@
       <div class="hero-content">
         <h1>Personal Bankruptcy</h1>
         <p>Confident, local guidance for a fresh financial start.</p>
+        <p>Learn how Chapter&nbsp;7 or Chapter&nbsp;13 can help you protect assets and move forward.</p>
       </div>
     </section>
 

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -32,8 +32,15 @@
     </nav>
   </header>
 
+  <section class="hero hero-pay">
+    <div class="hero-content">
+      <h1>Privacy Policy</h1>
+      <p>Your information stays protected.</p>
+      <p>Read how we handle the data you share with the Law Office of Robert Pohl.</p>
+    </div>
+  </section>
+
   <section class="bg-white">
-    <h1 style="text-align:center;">Privacy Policy</h1>
     <p>The Law Office of Robert Pohl respects your privacy. We collect information that you voluntarily provide, such as through contact forms, emails, or phone calls. This information is used solely to respond to your inquiries and to provide legal services. We do not sell or share personal information with third parties.</p>
     <p>Basic website analytics may be used to understand visitor trends, but these tools do not identify individual users. Submitting information through this site does not create an attorney-client relationship. Please do not send confidential information until an attorney-client relationship has been established.</p>
     <p>We may update this policy from time to time. Continued use of the site constitutes acceptance of any changes. For questions about this policy, please contact us directly.</p>

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -33,12 +33,15 @@
   </header>
   
   <section class="hero hero-ready">
-    <h1>Ready to File?</h1>
+    <div class="hero-content">
+      <h1>Ready to File?</h1>
+      <p>Prepare with confidence.</p>
+      <p>Use this checklist to gather documents and complete required steps before filing.</p>
+    </div>
   </section>
 
   <section class="bg-midnight">
     <h2 class="section-title">Checklist</h2>
-    <p class="section-subtitle">Get organized and take the first steps toward a fresh start.</p>
   </section>
 
   <section class="bg-gray">

--- a/testimonials.html
+++ b/testimonials.html
@@ -33,7 +33,11 @@
   </header>
   
   <section class="hero hero-testimonials">
-    <h1>Testimonials</h1>
+    <div class="hero-content">
+      <h1>Testimonials</h1>
+      <p>Real stories of relief and renewal.</p>
+      <p>See how individuals and businesses in the Virgin Islands regained control of their finances.</p>
+    </div>
   </section>
 
   <section class="bg-white" id="testimonials">


### PR DESCRIPTION
## Summary
- Add centered hero blocks with tagline and intro text to non-index pages for clearer page overviews.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689539e6c3d88321ba2d275ebfcc63c1