### PR TITLE
Add canonical URLs and global SEO meta tags

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,6 +10,13 @@
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/about.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <link rel="canonical" href="https://vibankruptcy.com/about.html" />
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VI Bankruptcy" />
+  <meta property="og:locale" content="en_US" />
+  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <meta name="theme-color" content="#132326" />
   <title>About | VI Bankruptcy</title>
 
   <!-- Google Fonts -->

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -10,6 +10,13 @@
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/business-bankruptcy.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <link rel="canonical" href="https://vibankruptcy.com/business-bankruptcy.html" />
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VI Bankruptcy" />
+  <meta property="og:locale" content="en_US" />
+  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <meta name="theme-color" content="#132326" />
   <title>Business Bankruptcy | VI Bankruptcy</title>
 
   <!-- Google Fonts -->

--- a/contact.html
+++ b/contact.html
@@ -10,6 +10,13 @@
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/contact.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <link rel="canonical" href="https://vibankruptcy.com/contact.html" />
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VI Bankruptcy" />
+  <meta property="og:locale" content="en_US" />
+  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <meta name="theme-color" content="#132326" />
   <title>Contact | VI Bankruptcy</title>
 
   <!-- Google Fonts -->

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -10,6 +10,13 @@
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/disclaimer.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <link rel="canonical" href="https://vibankruptcy.com/disclaimer.html" />
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VI Bankruptcy" />
+  <meta property="og:locale" content="en_US" />
+  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <meta name="theme-color" content="#132326" />
   <title>Disclaimer | VI Bankruptcy</title>
 
   <!-- Google Fonts -->

--- a/faq.html
+++ b/faq.html
@@ -10,6 +10,13 @@
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/faq.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <link rel="canonical" href="https://vibankruptcy.com/faq.html" />
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VI Bankruptcy" />
+  <meta property="og:locale" content="en_US" />
+  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <meta name="theme-color" content="#132326" />
   <title>Bankruptcy FAQ | VI Bankruptcy</title>
 
   <!-- Google Fonts -->

--- a/index.html
+++ b/index.html
@@ -10,6 +10,13 @@
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/index.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <link rel="canonical" href="https://vibankruptcy.com/index.html" />
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VI Bankruptcy" />
+  <meta property="og:locale" content="en_US" />
+  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <meta name="theme-color" content="#132326" />
   <title>VI Bankruptcy | Virgin Islands Debt Relief Attorney</title>
 
   <!-- Google Fonts -->

--- a/pay-online.html
+++ b/pay-online.html
@@ -10,6 +10,13 @@
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/pay-online.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <link rel="canonical" href="https://vibankruptcy.com/pay-online.html" />
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VI Bankruptcy" />
+  <meta property="og:locale" content="en_US" />
+  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <meta name="theme-color" content="#132326" />
   <title>Pay Online | VI Bankruptcy</title>
 
   <!-- Google Fonts -->

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -10,6 +10,13 @@
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/personal-bankruptcy.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <link rel="canonical" href="https://vibankruptcy.com/personal-bankruptcy.html" />
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VI Bankruptcy" />
+  <meta property="og:locale" content="en_US" />
+  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <meta name="theme-color" content="#132326" />
     <title>Personal Bankruptcy | VI Bankruptcy</title>
 
     <!-- Google Fonts -->

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -10,6 +10,13 @@
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/privacy-policy.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <link rel="canonical" href="https://vibankruptcy.com/privacy-policy.html" />
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VI Bankruptcy" />
+  <meta property="og:locale" content="en_US" />
+  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <meta name="theme-color" content="#132326" />
   <title>Privacy Policy | VI Bankruptcy</title>
 
   <!-- Google Fonts -->

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -10,6 +10,13 @@
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/ready-to-file.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <link rel="canonical" href="https://vibankruptcy.com/ready-to-file.html" />
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VI Bankruptcy" />
+  <meta property="og:locale" content="en_US" />
+  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <meta name="theme-color" content="#132326" />
   <title>Ready to File? Checklist | VI Bankruptcy</title>
 
   <!-- Google Fonts -->

--- a/testimonials.html
+++ b/testimonials.html
@@ -10,6 +10,13 @@
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/testimonials.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <link rel="canonical" href="https://vibankruptcy.com/testimonials.html" />
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VI Bankruptcy" />
+  <meta property="og:locale" content="en_US" />
+  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <meta name="theme-color" content="#132326" />
   <title>Testimonials | VI Bankruptcy</title>
 
   <!-- Google Fonts -->


### PR DESCRIPTION
## Summary
- add canonical tags and global SEO meta settings across all HTML pages
- include robots directives, Open Graph site info, preconnect, and theme color in heads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68959ce29fd88321980285ca06f477b0