### PR TITLE
Improve hero background positioning

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -166,6 +166,7 @@ a:hover {
   min-height: 420px;
   background: url("https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/7281805b-ff6f-4d66-ade8-d8c4bcc2d500/public")
     center/cover no-repeat;
+  background-position: top center;
   display: flex;
   align-items: center;
   padding: 0 1.25rem;
@@ -242,6 +243,13 @@ section > * {
 
 .hero {
   padding: 0 1.25rem;
+}
+
+@media (min-width: 992px) {
+  .hero {
+    height: 70vh;
+    background-position: top center;
+  }
 }
 
 h2 {


### PR DESCRIPTION
## Summary
- Bias hero background upward to show more of the image
- Add desktop breakpoint to increase hero height and maintain top-centered image

## Testing
- `npx stylelint styles.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68964d4208308321b413859ad5f90999