### PR TITLE
Revamp branding and content across site

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Call to Action:
 Ready to get out of debt? <strong>Contact us today</strong> for a free, confidential consultation. [Contact Us Button]
 -------------------------------------------------------------------
 Footer: 
-Logo | Law Office of Robert Pohl, VI Bankruptcy  
+Logo | POHL BANKRUPTCY, LLC, VI Bankruptcy  
 St. Thomas: 5316 Yacht Haven Grande, Suite N-104 Box 30, St. Thomas, VI 00802  
 St. Croix: 4500 Sion Farm, Suite 1, Christiansted, VI 00820  
 Phone: 888-676-4598  |  Email: info@viBankruptcy.com  
@@ -530,7 +530,7 @@ Local icons – maybe a tiny icon of a palm tree or a lighthouse (the VI does h
 These icons will be in line with the color scheme (maybe in teal or navy) and not oversized. They should complement the text, not overpower it.
 All images will be optimized for web (compressed appropriately) to ensure they don’t slow the site down. We will use modern formats like WebP if possible, with fallbacks for older browsers, which Cloudflare can also help optimize. Additionally, we will include descriptive alt text for each image for accessibility (e.g., <img src="couple-relieved.jpg" alt="A relieved couple reviewing finances with a professional advisor">).
 Logo and Branding: The site currently likely uses just a text treatment (“Pohl Bankruptcy” etc.). We will create a simple logo for viBankruptcy.com. Options for the logo:
-A text-based logo that says “VI Bankruptcy” (with perhaps a small tagline like “Law Office of Robert Pohl” beneath it in smaller text). We can use the same serif font from headings or a complementary font for the logo to give it a slight distinction. “VI” might be stylized in the accent color and “Bankruptcy” in navy, for example.
+A text-based logo that says “VI Bankruptcy” (with perhaps a small tagline like “POHL BANKRUPTCY, LLC” beneath it in smaller text). We can use the same serif font from headings or a complementary font for the logo to give it a slight distinction. “VI” might be stylized in the accent color and “Bankruptcy” in navy, for example.
 Alongside the text, a minimal graphic element could be included: for instance, integrating the shape of the Virgin Islands or a justice scale. One concept: the outline of St. Thomas and St. Croix (the main islands) with a balanced scale overlay – but that might be too detailed for a small logo. Another concept: a simple icon of a lighthouse or anchor (symbolizing guidance and stability) paired with the text. Or even a wave graphic underlining the text (suggesting the sea/island).
 We’ll ensure the logo works on both light and dark backgrounds. Likely we’ll use a dark version (navy text on white) for the header (white background) and a light version (white text on navy) for the footer or anywhere on a dark background.
 A branding guide (style sheet) will document the exact colors (hex codes for the blues, etc.), the fonts chosen, and how to use the logo. For example, it will specify minimum padding around the logo, not stretching/distorting it, and the font sizes for headings and body in CSS to maintain consistency.
@@ -583,7 +583,7 @@ Call to Action:
 Ready to get out of debt? <strong>Contact us today</strong> for a free, confidential consultation. [Contact Us Button]
 -------------------------------------------------------------------
 Footer: 
-Logo | Law Office of Robert Pohl, VI Bankruptcy  
+Logo | POHL BANKRUPTCY, LLC, VI Bankruptcy  
 St. Thomas: 5316 Yacht Haven Grande, Suite N-104 Box 30, St. Thomas, VI 00802  
 St. Croix: 4500 Sion Farm, Suite 1, Christiansted, VI 00820  
 Phone: 888-676-4598  |  Email: info@viBankruptcy.com  

--- a/about.html
+++ b/about.html
@@ -29,6 +29,7 @@
   <header class="site-header">
     <a href="index.html" class="logo-link">
       <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>
     <nav>
@@ -58,11 +59,12 @@
   <section class="bg-white" id="about">
     <h2 class="section-title">About Us</h2>
     <div class="about-wrapper">
+      <!-- TODO: replace photo with new professional image -->
       <img class="about-photo" src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/1ab4fdc6-aa8f-4845-1760-5d6bdbd1e300/public" alt="Robert A. Pohl - Bankruptcy Attorney" />
       <div class="about-text">
         <h3 class="about-heading">Robert A. Pohl – Bankruptcy Attorney</h3>
         <p>Robert A. Pohl is a seasoned bankruptcy attorney holding a J.D., LL.M. in Tax, and an MBA. Admitted in the U.S. Virgin Islands and multiple states, he has spent more than 25&nbsp;years helping individuals and businesses overcome debt.</p>
-        <p>"I believe in treating every client like family," Robert says. His philosophy centers on delivering straightforward advice with compassion and confidentiality.</p>
+        <p>“Each client is unique, and each situation is unique. The difference between good and amazing service is not only addressing the common problems but tailoring solutions to attend to each detail that is unique. I believe in taking the time to get to know each client and making sure that they are well taken care of.”</p>
       </div>
     </div>
   </section>
@@ -82,7 +84,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · POHL BANKRUPTCY, LLC · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 
 <script>

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -29,6 +29,7 @@
   <header class="site-header">
     <a href="index.html" class="logo-link">
       <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>
     <nav>
@@ -91,7 +92,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · POHL BANKRUPTCY, LLC · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 
 <script>

--- a/contact.html
+++ b/contact.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="images/favicon.png" type="image/png" />
-  <meta name="description" content="Contact the Law Office of Robert Pohl for a free bankruptcy consultation in the Virgin Islands." />
+  <meta name="description" content="Contact POHL BANKRUPTCY, LLC for a free bankruptcy consultation in the Virgin Islands." />
   <meta property="og:title" content="Contact | VI Bankruptcy" />
-  <meta property="og:description" content="Contact the Law Office of Robert Pohl for a free bankruptcy consultation in the Virgin Islands." />
+  <meta property="og:description" content="Contact POHL BANKRUPTCY, LLC for a free bankruptcy consultation in the Virgin Islands." />
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/contact.html" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -29,6 +29,7 @@
   <header class="site-header">
     <a href="index.html" class="logo-link">
       <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>
     <nav>
@@ -101,7 +102,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · POHL BANKRUPTCY, LLC · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 
   <script>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="images/favicon.png" type="image/png" />
-  <meta name="description" content="Legal disclaimer for viBankruptcy.com and the Law Office of Robert Pohl." />
+  <meta name="description" content="Legal disclaimer for viBankruptcy.com and POHL BANKRUPTCY, LLC." />
   <meta property="og:title" content="Disclaimer | VI Bankruptcy" />
-  <meta property="og:description" content="Legal disclaimer for viBankruptcy.com and the Law Office of Robert Pohl." />
+  <meta property="og:description" content="Legal disclaimer for viBankruptcy.com and POHL BANKRUPTCY, LLC." />
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/disclaimer.html" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -29,6 +29,7 @@
   <header class="site-header">
     <a href="index.html" class="logo-link">
       <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>
     <nav>
@@ -57,13 +58,13 @@
 
   <section class="bg-white">
     <p>The information on this website is provided for general informational purposes only and should not be construed as legal advice on any subject matter. You should not act or refrain from acting on the basis of any content included in this site without seeking appropriate legal or other professional advice.</p>
-    <p>Use of this website or contacting the Law Office of Robert Pohl through this site does not create an attorney-client relationship. Please do not send confidential or time-sensitive information until such a relationship has been established.</p>
+    <p>Use of this website or contacting POHL BANKRUPTCY, LLC through this site does not create an attorney-client relationship. Please do not send confidential or time-sensitive information until such a relationship has been established.</p>
     <p>While we strive to keep the information on this site current, we make no guarantees about the accuracy or completeness of the information and disclaim liability for errors or omissions. Links to external websites are provided for convenience and do not imply endorsement.</p>
     <p><em>This website may be considered attorney advertising in some jurisdictions. Past results do not guarantee similar outcomes.</em></p>
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · POHL BANKRUPTCY, LLC · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 
 <script>

--- a/faq.html
+++ b/faq.html
@@ -29,6 +29,7 @@
   <header class="site-header">
     <a href="index.html" class="logo-link">
       <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>
     <nav>
@@ -88,7 +89,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · POHL BANKRUPTCY, LLC · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 
 <script>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
   <header class="site-header">
     <a href="index.html" class="logo-link">
       <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>
     <nav>
@@ -147,7 +148,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · POHL BANKRUPTCY, LLC · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 
 <script>

--- a/pay-online.html
+++ b/pay-online.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="images/favicon.png" type="image/png" />
-  <meta name="description" content="Secure online payment portal for clients of the Law Office of Robert Pohl." />
+  <meta name="description" content="Secure online payment portal for clients of POHL BANKRUPTCY, LLC." />
   <meta property="og:title" content="Pay Online | VI Bankruptcy" />
-  <meta property="og:description" content="Secure online payment portal for clients of the Law Office of Robert Pohl." />
+  <meta property="og:description" content="Secure online payment portal for clients of POHL BANKRUPTCY, LLC." />
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/pay-online.html" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -29,6 +29,7 @@
   <header class="site-header">
     <a href="index.html" class="logo-link">
       <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>
     <nav>
@@ -64,7 +65,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · POHL BANKRUPTCY, LLC · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 
 <script>

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="images/favicon.png" type="image/png" />
-  <meta name="description" content="Guidance on Chapter 7 and Chapter 13 personal bankruptcy for Virgin Islands residents." />
+  <meta name="description" content="Guidance on Chapters 7, 11, 12 and 13 personal bankruptcy for Virgin Islands residents." />
   <meta property="og:title" content="Personal Bankruptcy | VI Bankruptcy" />
-  <meta property="og:description" content="Guidance on Chapter 7 and Chapter 13 personal bankruptcy for Virgin Islands residents." />
+  <meta property="og:description" content="Guidance on Chapters 7, 11, 12 and 13 personal bankruptcy for Virgin Islands residents." />
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/personal-bankruptcy.html" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -35,7 +35,8 @@
           src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public"
           alt="viBankruptcy logo"
         />
-      </a>
+        <span class="logo-text">Pohl Bankruptcy</span>
+    </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>
     <nav>
         <a href="about.html">About</a>
@@ -57,18 +58,15 @@
       <div class="hero-content">
         <h1>Personal Bankruptcy</h1>
         <p>Confident, local guidance for a fresh financial start.</p>
-        <p>Learn how Chapter&nbsp;7 or Chapter&nbsp;13 can help you protect assets and move forward.</p>
+        <p>Learn how Chapters&nbsp;7, 11, 12 and 13 can help you protect assets and move forward.</p>
       </div>
     </section>
 
     <section class="bg-white">
       <div class="intro-text">
-        <h2>Chapter 7 &amp; Chapter 13 for Individuals and Families</h2>
+        <h2>Chapters 7, 11, 12 &amp; 13 for Individuals and Families</h2>
         <p>
-          Debt can feel overwhelming, but bankruptcy law was designed to give
-          honest people a second chance. The Law Office of Robert Pohl helps
-          Virgin Islanders use federal protections to erase or reorganize debt
-          while keeping the assets that matter most.
+          Debt can feel overwhelming, but bankruptcy law was designed to give honest people a second chance. POHL BANKRUPTCY, LLC guides Virgin Islanders through Chapters 7, 11, 12 and 13 to use federal protections to erase or reorganize debt while keeping the assets that matter most.
         </p>
       </div>
     </section>
@@ -107,6 +105,16 @@
         <li>Keep your property while making payments.</li>
         <li>Must have regular income within debt limits.</li>
       </ul>
+    </section>
+
+    <section class="bg-gray">
+      <h3><span style="font-size: 2rem">🏢</span>Chapter&nbsp;11 Bankruptcy (Individuals)</h3>
+      <p>Chapter 11 bankruptcy provisions are complex and require in-person consultation to thoroughly explain and discuss.</p>
+    </section>
+
+    <section class="bg-white">
+      <h3><span style="font-size: 2rem">🌾</span>Chapter&nbsp;12 Bankruptcy</h3>
+      <p>This bankruptcy is for individuals who substantially rely upon farming or fishing. It is similar to a Chapter 13 in that the individual completes all of the same paperwork to file the bankruptcy. However, the Chapter 12 plan differs in form and functionality. There are numerous benefits to filing a Chapter 12 as opposed to a Chapter 13 including, but not limited to, reducing capital gain taxes on sale of assets after filing the bankruptcy, more flexible payment terms and higher debt limits. If you do not qualify for a Chapter 7 and you obtain a substantial amount of your income from farming or fishing, you will want to file a Chapter 12.</p>
     </section>
 
     <section class="bg-gray">
@@ -173,7 +181,7 @@
     </section>
 
     <footer>
-      &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl ·
+      &copy; 2025 viBankruptcy.com · POHL BANKRUPTCY, LLC ·
       <a href="pay-online.html">Pay Online</a> ·
       <a href="privacy-policy.html">Privacy Policy</a> ·
       <a href="disclaimer.html">Disclaimer</a>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="images/favicon.png" type="image/png" />
-  <meta name="description" content="Privacy practices of viBankruptcy.com and the Law Office of Robert Pohl." />
+  <meta name="description" content="Privacy practices of viBankruptcy.com and POHL BANKRUPTCY, LLC." />
   <meta property="og:title" content="Privacy Policy | VI Bankruptcy" />
-  <meta property="og:description" content="Privacy practices of viBankruptcy.com and the Law Office of Robert Pohl." />
+  <meta property="og:description" content="Privacy practices of viBankruptcy.com and POHL BANKRUPTCY, LLC." />
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/privacy-policy.html" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -29,6 +29,7 @@
   <header class="site-header">
     <a href="index.html" class="logo-link">
       <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>
     <nav>
@@ -51,19 +52,19 @@
     <div class="hero-content">
       <h1>Privacy Policy</h1>
       <p>Your information stays protected.</p>
-      <p>Read how we handle the data you share with the Law Office of Robert Pohl.</p>
+      <p>Read how we handle the data you share with POHL BANKRUPTCY, LLC.</p>
     </div>
   </section>
 
   <section class="bg-white">
-    <p>The Law Office of Robert Pohl respects your privacy. We collect information that you voluntarily provide, such as through contact forms, emails, or phone calls. This information is used solely to respond to your inquiries and to provide legal services. We do not sell or share personal information with third parties.</p>
+    <p>The POHL BANKRUPTCY, LLC respects your privacy. We collect information that you voluntarily provide, such as through contact forms, emails, or phone calls. This information is used solely to respond to your inquiries and to provide legal services. We do not sell or share personal information with third parties.</p>
     <p>Basic website analytics may be used to understand visitor trends, but these tools do not identify individual users. Submitting information through this site does not create an attorney-client relationship. Please do not send confidential information until an attorney-client relationship has been established.</p>
     <p>We may update this policy from time to time. Continued use of the site constitutes acceptance of any changes. For questions about this policy, please contact us directly.</p>
     <p><em>This website may be considered attorney advertising in some jurisdictions. Past results do not guarantee similar outcomes.</em></p>
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · POHL BANKRUPTCY, LLC · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 
 <script>

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="images/favicon.png" type="image/png" />
-  <meta name="description" content="Checklist of documents to prepare when filing bankruptcy with the Law Office of Robert Pohl." />
+  <meta name="description" content="Checklist of documents to prepare when filing bankruptcy with POHL BANKRUPTCY, LLC." />
   <meta property="og:title" content="Ready to File? Checklist | VI Bankruptcy" />
-  <meta property="og:description" content="Checklist of documents to prepare when filing bankruptcy with the Law Office of Robert Pohl." />
+  <meta property="og:description" content="Checklist of documents to prepare when filing bankruptcy with POHL BANKRUPTCY, LLC." />
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/ready-to-file.html" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -29,6 +29,7 @@
   <header class="site-header">
     <a href="index.html" class="logo-link">
       <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>
     <nav>
@@ -85,7 +86,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · POHL BANKRUPTCY, LLC · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 
 <script>

--- a/styles.css
+++ b/styles.css
@@ -154,9 +154,25 @@ a:hover {
 .site-header nav .dropdown:hover .dropdown-content {
   display: block;
 }
+.logo-link {
+  display:flex;
+  align-items:center;
+}
 .logo-link img {
-  height: 48px;
-  width: auto;
+  height:48px;
+  width:auto;
+}
+.logo-text {
+  display:none;
+  color:#fff;
+  margin-left:0.5rem;
+  font-family:"Merriweather", serif;
+  font-size:1.25rem;
+}
+@media (min-width:768px) {
+  .logo-link img { height:64px; }
+  .logo-text { display:inline-block; }
+  .hero { background-position: top center; }
 }
 
 /* Hero */

--- a/testimonials.html
+++ b/testimonials.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="images/favicon.png" type="image/png" />
-  <meta name="description" content="Read testimonials from clients of the Law Office of Robert Pohl in the Virgin Islands." />
+  <meta name="description" content="Read testimonials from clients of POHL BANKRUPTCY, LLC in the Virgin Islands." />
   <meta property="og:title" content="Testimonials | VI Bankruptcy" />
-  <meta property="og:description" content="Read testimonials from clients of the Law Office of Robert Pohl in the Virgin Islands." />
+  <meta property="og:description" content="Read testimonials from clients of POHL BANKRUPTCY, LLC in the Virgin Islands." />
   <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
   <meta property="og:url" content="https://vibankruptcy.com/testimonials.html" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -29,6 +29,7 @@
   <header class="site-header">
     <a href="index.html" class="logo-link">
       <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>
     <nav>
@@ -84,7 +85,7 @@
   </section>
 
   <footer>
-    &copy; 2025 viBankruptcy.com · Law Office of Robert Pohl · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
+    &copy; 2025 viBankruptcy.com · POHL BANKRUPTCY, LLC · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
 
 <script>


### PR DESCRIPTION
## Summary
- Add desktop "Pohl Bankruptcy" wordmark with larger logo and adjust hero position for full bird image
- Replace about-page quote and prep for new professional photo
- Expand personal bankruptcy page to cover Chapters 7, 11, 12 & 13 and update firm name sitewide

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68964b1956f88321ad168b1002ab1a31