### PR TITLE
Expand about page with detailed professional background

### DIFF
--- a/about.html
+++ b/about.html
@@ -67,6 +67,37 @@
       </div>
     </div>
   </section>
+  <section class="bg-white">
+    <div class="about-detailed">
+      <h2 class="section-title">About Robert Pohl</h2>
+      <p>Robert Pohl is the President of POHL, PA in Greenville, South Carolina. His boutique practice focuses on financial litigation, including distressed debt purchases, hard money lending, bankruptcy, tax litigation and tax planning, estate planning, wills and trusts, securities offerings and private placements, real estate closings, business formation, and general corporate legal services for small and mid‑sized organizations. He built a fully integrated, paperless practice that manages 749 clients and generates more than $1&nbsp;million in annual fees as a sole practitioner, using automated systems, a third party answering service, and customized practice software.</p>
+      <h3>Bankruptcy Focus</h3>
+      <p>Through POHL BANKRUPTCY, LLC, established in 2021, Robert represents debtors in bankruptcy filings, related litigation, and associated matters. His prior work as a Corporate Bankruptcy Associate included interviewing and negotiating with individuals and businesses, restructuring liabilities, and when necessary filing Chapter 7 equity buyouts or Chapter 11 reorganizations. He drafted, filed, and argued adversary proceedings, motions, applications, disclosure statements, plans, objections, and responses before the U.S. Bankruptcy Court, and he negotiated compromises with federal and state taxing authorities. He has also handled discovery, depositions, interrogatories, subpoenas, and additional litigation tasks common in bankruptcy practice.</p>
+      <h3>Additional Legal and Business Experience</h3>
+      <p>Robert’s background includes legal, compliance, and executive roles tied to complex finance, securitization, real estate, and corporate matters. As Manager of Legal Services Compliance for Resurgent Capital Services, LP in Greenville, South Carolina, he analyzed distressed asset portfolios and directed bankruptcy litigation, foreclosure, and international mortgage servicing for secured accounts in the United States, Canada, the Commonwealth of the Bahamas, Mexico, and the Dominican Republic, addressing claims, motions for relief, lien issues, reaffirmations, settlements, loan modifications, forbearances, mediations, stays, notices, trustee sales, TILA and RESPA claims, and post‑judgment recovery actions.</p>
+      <p>As an associate at Fell, Marking, Abkin, Montgomery, Granet &amp; Raney, LLP in Santa Barbara, California, he prepared formation and financing documents such as Private Placement Memorandums, Offering Circulars, and organizational documents, and drafted research memoranda related to tax, liability, insurance, real property, and land use.</p>
+      <p>He served as General Counsel and Executive Managing Director for Quality Home Loans and Quality Loans in California, structuring capital markets and corporate operations that included private equity raises, credit facilities, warehouse lines, and securitizations. He negotiated leases and software agreements, established compliance procedures, and coordinated multiple Chapter 11 cases and a Chapter 7 case.</p>
+      <p>As First Vice President and Senior Legal Counsel at Countrywide Home Loans, Inc. in Calabasas, California, he managed counsel and administrators for high‑volume mortgage loan purchase, sale, and securitization work, drafting and negotiating purchase, pooling and servicing, indemnity, and related agreements while advising on underwriting, funding, servicing, title issues, compliance, and consumer finance litigation.</p>
+      <p>Earlier in his career, as Corporate Attorney for the California Association of REALTORS, Inc. in Los Angeles, he advised on entity formation, venture capital, acquisitions, intellectual property, and contracts, maintaining corporate records and compliance for related entities and PAC matters.</p>
+      <p>He began as a Senior Tax Specialist at KPMG, LLP in Los Angeles, developing multi‑state tax strategies, negotiating incentives, and leading work that realized a significant sales and use tax refund using California Enterprise Zone Credits and Manufacturer’s Investment Credits.</p>
+      <h3>Related Companies</h3>
+      <p>Robert has founded and managed several related businesses that support clients involved in real estate, title, and asset management: POHL CAPITAL, LLC (doing business as POHL REALTY) for brokerage of distressed residential and commercial real estate, POHL TITLE COMPANY, LLC as a title insurance agency licensed with First American Title Insurance Company in South Carolina, POHL PROPERTY MANAGEMENT, LLC for residential and commercial property management, and POHL TALENT MANAGEMENT, LLC.</p>
+      <h3>Education</h3>
+      <p>LL.M., Taxation, University of San Diego School of Law, Cum Laude, 2000</p>
+      <p>Juris Doctor, University of San Diego School of Law, 1999</p>
+      <p>MBA, International Business, University of San Diego Graduate Business School, 1999</p>
+      <p>B.A., English Literature, Boston College, 1991</p>
+      <p>Merit Certificates: International Corporate Structure, Institute on International and Comparative Law, Paris; English Literature, Harris Manchester College, Oxford University</p>
+      <h3>Admissions</h3>
+      <p>California 2000, District of Columbia 2002, Tennessee 2008, North Carolina 2009, South Carolina 2010</p>
+      <p>United States Tax Court 2000, United States Federal Courts 2000, United States Supreme Court 2006, United States Bankruptcy Court 2010</p>
+      <h3>Additional Licenses</h3>
+      <p>Licensed Insurance Broker, South Carolina 2013</p>
+      <p>Licensed Real Estate Broker, South Carolina 2012</p>
+      <h3>Planned Geographic Growth</h3>
+      <p>Plans include expansion to North Carolina locations such as Charlotte, Asheville, and Greenville, the U.S. Virgin Islands in St. Thomas, and Tennessee locations including Nashville, Knoxville, and Chattanooga.</p>
+    </div>
+  </section>
 
   <section class="bg-gray">
     <h2 class="section-title">The Pohl Approach</h2>


### PR DESCRIPTION
## Summary
- extend About page with a comprehensive professional biography for Robert Pohl
- highlight bankruptcy expertise, broader legal experience, and related business ventures
- document education, admissions, licenses, and planned geographic growth

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68966a6582108321b41dd949da07149f