### PR TITLE
feat: expand about page biography

### DIFF
--- a/about.html
+++ b/about.html
@@ -69,33 +69,103 @@
   </section>
   <section class="bg-white">
     <div class="about-detailed">
-      <h2 class="section-title">About Robert Pohl</h2>
-      <p>Robert Pohl is the President of POHL, PA in Greenville, South Carolina. His boutique practice focuses on financial litigation, including distressed debt purchases, hard money lending, bankruptcy, tax litigation and tax planning, estate planning, wills and trusts, securities offerings and private placements, real estate closings, business formation, and general corporate legal services for small and mid‑sized organizations. He built a fully integrated, paperless practice that manages 749 clients and generates more than $1&nbsp;million in annual fees as a sole practitioner, using automated systems, a third party answering service, and customized practice software.</p>
-      <h3>Bankruptcy Focus</h3>
-      <p>Through POHL BANKRUPTCY, LLC, established in 2021, Robert represents debtors in bankruptcy filings, related litigation, and associated matters. His prior work as a Corporate Bankruptcy Associate included interviewing and negotiating with individuals and businesses, restructuring liabilities, and when necessary filing Chapter 7 equity buyouts or Chapter 11 reorganizations. He drafted, filed, and argued adversary proceedings, motions, applications, disclosure statements, plans, objections, and responses before the U.S. Bankruptcy Court, and he negotiated compromises with federal and state taxing authorities. He has also handled discovery, depositions, interrogatories, subpoenas, and additional litigation tasks common in bankruptcy practice.</p>
-      <h3>Additional Legal and Business Experience</h3>
-      <p>Robert’s background includes legal, compliance, and executive roles tied to complex finance, securitization, real estate, and corporate matters. As Manager of Legal Services Compliance for Resurgent Capital Services, LP in Greenville, South Carolina, he analyzed distressed asset portfolios and directed bankruptcy litigation, foreclosure, and international mortgage servicing for secured accounts in the United States, Canada, the Commonwealth of the Bahamas, Mexico, and the Dominican Republic, addressing claims, motions for relief, lien issues, reaffirmations, settlements, loan modifications, forbearances, mediations, stays, notices, trustee sales, TILA and RESPA claims, and post‑judgment recovery actions.</p>
-      <p>As an associate at Fell, Marking, Abkin, Montgomery, Granet &amp; Raney, LLP in Santa Barbara, California, he prepared formation and financing documents such as Private Placement Memorandums, Offering Circulars, and organizational documents, and drafted research memoranda related to tax, liability, insurance, real property, and land use.</p>
-      <p>He served as General Counsel and Executive Managing Director for Quality Home Loans and Quality Loans in California, structuring capital markets and corporate operations that included private equity raises, credit facilities, warehouse lines, and securitizations. He negotiated leases and software agreements, established compliance procedures, and coordinated multiple Chapter 11 cases and a Chapter 7 case.</p>
-      <p>As First Vice President and Senior Legal Counsel at Countrywide Home Loans, Inc. in Calabasas, California, he managed counsel and administrators for high‑volume mortgage loan purchase, sale, and securitization work, drafting and negotiating purchase, pooling and servicing, indemnity, and related agreements while advising on underwriting, funding, servicing, title issues, compliance, and consumer finance litigation.</p>
-      <p>Earlier in his career, as Corporate Attorney for the California Association of REALTORS, Inc. in Los Angeles, he advised on entity formation, venture capital, acquisitions, intellectual property, and contracts, maintaining corporate records and compliance for related entities and PAC matters.</p>
-      <p>He began as a Senior Tax Specialist at KPMG, LLP in Los Angeles, developing multi‑state tax strategies, negotiating incentives, and leading work that realized a significant sales and use tax refund using California Enterprise Zone Credits and Manufacturer’s Investment Credits.</p>
-      <h3>Related Companies</h3>
-      <p>Robert has founded and managed several related businesses that support clients involved in real estate, title, and asset management: POHL CAPITAL, LLC (doing business as POHL REALTY) for brokerage of distressed residential and commercial real estate, POHL TITLE COMPANY, LLC as a title insurance agency licensed with First American Title Insurance Company in South Carolina, POHL PROPERTY MANAGEMENT, LLC for residential and commercial property management, and POHL TALENT MANAGEMENT, LLC.</p>
+      <h2 class="section-title">Robert Pohl</h2>
+
+      <div class="contact-block">
+        <p><strong>U.S. Virgin Islands Offices</strong><br />
+        St. Thomas: 5316 Yacht Haven Grande, Suite N‑104, Box 30, St. Thomas, VI 00802<br />
+        St. John: 5000 Estate Enighed, P.O. Box 343, St. John, VI 00830<br />
+        St. Croix: 6002 Diamond Ruby, Suite 3, PMB 633, Christiansted, VI 00820</p>
+        <p>Phone: Office (340) 203‑3333 • Mobile (864) 361‑4827<br />
+        Email: <a href="mailto:Robert@POHLPA.com">Robert@POHLPA.com</a></p>
+      </div>
+
+      <h3>Professional Summary</h3>
+      <p>Bankruptcy and financial‑litigation attorney (practicing since 2000) serving individuals and businesses across the U.S. Virgin Islands through offices on St. Thomas, St. John, and St. Croix. Founder of POHL, P.A. and POHL Bankruptcy, LLC. Experience includes distressed debt, bankruptcy filings and litigation, tax litigation and planning, corporate and securities work, real estate, estate planning, and related matters.</p>
+
+      <h3>Legal Experience</h3>
+
+      <h4>POHL, P.A. — President • 2012–Present</h4>
+      <p>Established a boutique law firm specializing in financial litigation including, but not limited to, distressed debt purchases, hard money lending, bankruptcy, tax litigation, tax planning, estate planning, wills and trusts formation and management, security offerings, private placements, real estate closings, business formation, general corporate legal services, and other related legal services for small to mid‑sized executives, partnerships, companies and corporations.</p>
+      <p>Developed a fully integrated and paperless law practice that currently manages 749 clients and generates in excess of $1MM in annual fees as a sole practitioner with only a temporary paralegal utilizing automated systems, third‑party answering services and customized practice software.</p>
+
+      <h4>POHL Bankruptcy, LLC — Manager • 2021–Present</h4>
+      <p>Established a bankruptcy law firm specializing in only representing debtors in bankruptcy filings, litigation and related matters.</p>
+
+      <h4>POHL Capital, LLC (dba POHL Realty) — Manager • 201–Present</h4>
+      <p>Established a small real estate brokerage specializing in listing, marketing and selling distressed residential and commercial real estate.</p>
+
+      <h4>POHL Title Company, LLC — Manager &amp; Sole Member • 2012–Present</h4>
+      <p>Established and manage a title insurance agency licensed to issue title insurance with First American Title Insurance Company within South Carolina.</p>
+
+      <h4>POHL Talent Management, LLC (dba POHL Talent) — Manager • 2018–Present</h4>
+      <p>Established a small talent agency representing musicians, writers, actors, athletes, and other performers.</p>
+
+      <h4>POHL Property Management, LLC — Manager &amp; Sole Member • 2012–2013</h4>
+      <p>Established, managed and sold a property management business that managed residential and commercial property including, but not limited to, investment homes, a bar, a restaurant, and a hotel.</p>
+
+      <h4>Stodghill Law Firm Chartered — Associate • 2011–2012</h4>
+      <p>Performed the same duties and responsibilities as Corporate Bankruptcy Associate for The Cooper Law Firm.</p>
+
+      <h4>The Cooper Law Firm — Corporate Bankruptcy Associate • 2010–2011</h4>
+      <p>Interviewed, negotiated, and managed individuals and businesses in restructuring debt and monetizing assets by obtaining financing, restructuring liabilities and, if necessary, filing bankruptcy as a Chapter 7 equity buyout or Chapter 11 reorganization.</p>
+      <p>Drafted, filed and argued adversarial proceedings, motions, applications, settlements, disclosure statements, plans, objections, responses and all other matters before the U.S. Bankruptcy Court.</p>
+      <p>Negotiated and drafted compromises and settlement offers with federal and state taxing authorities.</p>
+      <p>Litigated adverse proceedings including conducting depositions, drafting interrogatories, subpoenas, and all other forms of discovery.</p>
+
+      <h4>Resurgent Capital Services, LP — Manager, Legal Services Compliance • 2009–2010</h4>
+      <p>Analyzed distressed asset portfolios secured by real estate (commercial and residential), personal property and/or intangible property—portfolios ranged from $2MM–$500MM.</p>
+      <p>Developed litigation and liquidation plans to maximize recovery through foreclosure, repossession, insurance claims, subrogation claims, indemnification claims, fraud claims and contract claims, generating maximum recoveries on government‑insured, privately insured, non‑conforming, conforming, secured and unsecured loans.</p>
+      <p>Managed bankruptcy litigation, foreclosure and international mortgage servicing departments overseeing secured accounts throughout the U.S., Canada, Bahamas, Mexico, and Dominican Republic, including claims filing, motions for relief from stay, claim objections, lien strips, §523 actions, reaffirmations, settlements, loan mods, forbearances, mediations, depositions, stay‑violation issues, notices of default, substitutions of trustee, trustee sale notices, trustee sales, publications of sale, TILA/RESPA claims, bidding instructions, deficiency claims filing, wage and bank account garnishments, judgment liens and related matters.</p>
+
+      <h4>Fell, Marking, Abkin, Montgomery, Granet &amp; Raney, LLP — Associate • 2008–2009</h4>
+      <p>Designed, produced and presented formation documents (PPMs, offering circulars, investor questionnaires, subscription agreements, articles, operating agreements, bylaws, minutes, stock certificates), federal and state licensing applications and related documentation to establish and finance businesses.</p>
+      <p>Drafted legal memos, briefs, opinions and research related to taxes, liability, insurance, real property, land use and other legal matters.</p>
+
+      <h4>Quality Loans, LLC — General Counsel, Executive Managing Director • 2007–2008</h4>
+      <p>Established a Delaware LLC to acquire/finance/establish a nationally chartered bank or broker‑dealer and to acquire, sell, securitize, broker, originate and trade mortgage loans and similar instruments.</p>
+      <p>Drafted and filed formation documents including PPM, state/federal applications and all materials required to be licensed to originate, sell, purchase and securitize financial instruments.</p>
+      <p>Negotiated leases, software agreements and other documentation; set up payroll, health benefits and company functions.</p>
+      <p>Raised $25.5MM in startup capital; drafted/negotiated credit lines for $250MM to finance acquisitions, originations and securitizations.</p>
+
+      <h4>Quality Home Loans — General Counsel, Executive Managing Director • 2006–2007</h4>
+      <p>Created and managed legal, correspondent and capital‑markets divisions completing ~$1B in mortgage originations, $1B in securities and purchasing ~$250MM of whole loans annually.</p>
+      <p>Developed marketing/sales strategy securing $30MM/month in correspondent purchases.</p>
+      <p>Drafted offering materials and related documents to raise $60MM in private equity and $50MM in short‑term commercial paper; established $300MM in credit facilities with hedge funds, national banks and institutional investors.</p>
+      <p>Managed four private equity funds ($60MM), three warehouse lines ($300MM) and seven securities averaging $150MM each.</p>
+      <p>Implemented compliance procedures; negotiated vendor agreements; advised senior management on HR, foreclosures, evictions, leases, acquisitions, mergers and reorganizations; coordinated four Chapter 11 and one Chapter 7 bankruptcies.</p>
+
+      <h4>Countrywide Home Loans, Inc. — First Vice President, Senior Legal Counsel • 2002–2006</h4>
+      <p>Managed attorneys/administrators to purchase, sell and securitize approximately $9B/month of mortgage loans.</p>
+      <p>Drafted/negotiated MLPA, indemnities, PSA, AARA, repurchase, servicing‑rights and related agreements; advised on underwriting, funding, servicing and title issues; developed compliance procedures; handled disputes; assisted in consumer‑finance litigation; monitored due diligence and compliance.</p>
+
+      <h4>California Association of REALTORS&reg;, Inc. — Corporate Attorney • 2001–2002</h4>
+      <p>Prepared formation documents, acquired venture capital and advised officers/directors across nine entities.</p>
+      <p>Assisted in acquisitions/mergers; IP (copyrights, trademarks, patents); negotiated and drafted diverse contracts; administered employee equity plan; maintained entity records; ensured compliance with campaign and political laws for two PACs.</p>
+
+      <h4>KPMG, LLP — Senior Tax Specialist • 2000–2001</h4>
+      <p>Interpreted 12 state tax/corporate codes; devised plans decreasing taxes by 80%+.</p>
+      <p>Implemented tax‑minimization plans via reorganizations/reincorporations; negotiated incentives; prepared feasibility studies worth several million dollars.</p>
+      <p>Realized a $20MM tax refund by supervising the collection/processing/certification of information to eliminate sales/use tax using California Enterprise Zone Credits and Manufacturer’s Investment Credits.</p>
+
       <h3>Education</h3>
-      <p>LL.M., Taxation, University of San Diego School of Law, Cum Laude, 2000</p>
-      <p>Juris Doctor, University of San Diego School of Law, 1999</p>
-      <p>MBA, International Business, University of San Diego Graduate Business School, 1999</p>
-      <p>B.A., English Literature, Boston College, 1991</p>
-      <p>Merit Certificates: International Corporate Structure, Institute on International and Comparative Law, Paris; English Literature, Harris Manchester College, Oxford University</p>
-      <h3>Admissions</h3>
-      <p>California 2000, District of Columbia 2002, Tennessee 2008, North Carolina 2009, South Carolina 2010</p>
-      <p>United States Tax Court 2000, United States Federal Courts 2000, United States Supreme Court 2006, United States Bankruptcy Court 2010</p>
+      <ul>
+        <li>LL.M., Taxation (Cum Laude) — University of San Diego School of Law, 2000</li>
+        <li>Juris Doctor — University of San Diego School of Law, 1999</li>
+        <li>MBA, International Business — University of San Diego Graduate Business School, 1999</li>
+        <li>Merit Certificate, International Corporate Structure — Institute on International &amp; Comparative Law, Paris, 1996</li>
+        <li>Baccalaureus Artium, English Literature — Boston College, 1991</li>
+        <li>Merit Certificate, English Literature — Harris Manchester College, Oxford University, 1990</li>
+      </ul>
+
+      <h3>Admissions &amp; Courts</h3>
+      <p>California (2000) • District of Columbia (2002) • Tennessee (2008) • North Carolina (2009) • South Carolina (2010) • United States Federal Courts (2000) • United States Tax Court (2000) • United States Supreme Court (2006) • United States Bankruptcy Court (2010).</p>
+
       <h3>Additional Licenses</h3>
-      <p>Licensed Insurance Broker, South Carolina 2013</p>
-      <p>Licensed Real Estate Broker, South Carolina 2012</p>
-      <h3>Planned Geographic Growth</h3>
-      <p>Plans include expansion to North Carolina locations such as Charlotte, Asheville, and Greenville, the U.S. Virgin Islands in St. Thomas, and Tennessee locations including Nashville, Knoxville, and Chattanooga.</p>
+      <ul>
+        <li>Insurance Broker: South Carolina (2013)</li>
+        <li>Real Estate Broker: South Carolina (2012)</li>
+      </ul>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- replace about page biography with detailed professional history, contact information, education, admissions, and licenses for Robert Pohl

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68966d7955b083219f9990121d0a3178