### PR TITLE
refactor about page for polished sections

### DIFF
--- a/about.html
+++ b/about.html
@@ -65,13 +65,12 @@
         <p>Robert A. Pohl is a seasoned bankruptcy attorney holding a J.D., LL.M. in Tax, and an MBA. Admitted in the U.S. Virgin Islands and multiple states, he has spent more than 25&nbsp;years helping individuals and businesses overcome debt.</p>
         <p>Each client is unique, and each situation is unique. The difference between good and amazing service is not only addressing the common problems but tailoring solutions to attend to each detail that is unique. I believe in taking the time to get to know each client and making sure that they are well taken care of.</p>
       </div>
-    </div>
+  </div>
   </section>
   <section class="bg-white">
-    <div class="about-detailed">
-      <h2 class="section-title">Robert Pohl</h2>
-
-      <div class="contact-block">
+    <div class="info-section">
+      <h2 class="section-title">Contact</h2>
+      <div class="contact-card">
         <p><strong>U.S. Virgin Islands Offices</strong><br />
         St. Thomas: 5316 Yacht Haven Grande, Suite N‑104, Box 30, St. Thomas, VI 00802<br />
         St. John: 5000 Estate Enighed, P.O. Box 343, St. John, VI 00830<br />
@@ -79,76 +78,113 @@
         <p>Phone: Office (340) 203‑3333 • Mobile (864) 361‑4827<br />
         Email: <a href="mailto:Robert@POHLPA.com">Robert@POHLPA.com</a></p>
       </div>
+    </div>
 
-      <h3>Professional Summary</h3>
+    <div class="info-section">
+      <h2 class="section-title">Professional Summary</h2>
       <p>Bankruptcy and financial‑litigation attorney (practicing since 2000) serving individuals and businesses across the U.S. Virgin Islands through offices on St. Thomas, St. John, and St. Croix. Founder of POHL, P.A. and POHL Bankruptcy, LLC. Experience includes distressed debt, bankruptcy filings and litigation, tax litigation and planning, corporate and securities work, real estate, estate planning, and related matters.</p>
+    </div>
 
-      <h3>Legal Experience</h3>
+    <div class="info-section">
+      <h2 class="section-title">Legal Experience</h2>
+      <div class="experience">
+        <div class="job">
+          <h4>POHL, P.A. — President • 2012–Present</h4>
+          <p>Established a boutique law firm specializing in financial litigation including, but not limited to, distressed debt purchases, hard money lending, bankruptcy, tax litigation, tax planning, estate planning, wills and trusts formation and management, security offerings, private placements, real estate closings, business formation, general corporate legal services, and other related legal services for small to mid‑sized executives, partnerships, companies and corporations.</p>
+          <p>Developed a fully integrated and paperless law practice that currently manages 749 clients and generates in excess of $1MM in annual fees as a sole practitioner with only a temporary paralegal utilizing automated systems, third‑party answering services and customized practice software.</p>
+        </div>
 
-      <h4>POHL, P.A. — President • 2012–Present</h4>
-      <p>Established a boutique law firm specializing in financial litigation including, but not limited to, distressed debt purchases, hard money lending, bankruptcy, tax litigation, tax planning, estate planning, wills and trusts formation and management, security offerings, private placements, real estate closings, business formation, general corporate legal services, and other related legal services for small to mid‑sized executives, partnerships, companies and corporations.</p>
-      <p>Developed a fully integrated and paperless law practice that currently manages 749 clients and generates in excess of $1MM in annual fees as a sole practitioner with only a temporary paralegal utilizing automated systems, third‑party answering services and customized practice software.</p>
+        <div class="job">
+          <h4>POHL Bankruptcy, LLC — Manager • 2021–Present</h4>
+          <p>Established a bankruptcy law firm specializing in only representing debtors in bankruptcy filings, litigation and related matters.</p>
+        </div>
 
-      <h4>POHL Bankruptcy, LLC — Manager • 2021–Present</h4>
-      <p>Established a bankruptcy law firm specializing in only representing debtors in bankruptcy filings, litigation and related matters.</p>
+        <div class="job">
+          <h4>POHL Capital, LLC (dba POHL Realty) — Manager • 201–Present</h4>
+          <p>Established a small real estate brokerage specializing in listing, marketing and selling distressed residential and commercial real estate.</p>
+        </div>
 
-      <h4>POHL Capital, LLC (dba POHL Realty) — Manager • 201–Present</h4>
-      <p>Established a small real estate brokerage specializing in listing, marketing and selling distressed residential and commercial real estate.</p>
+        <div class="job">
+          <h4>POHL Title Company, LLC — Manager &amp; Sole Member • 2012–Present</h4>
+          <p>Established and manage a title insurance agency licensed to issue title insurance with First American Title Insurance Company within South Carolina.</p>
+        </div>
 
-      <h4>POHL Title Company, LLC — Manager &amp; Sole Member • 2012–Present</h4>
-      <p>Established and manage a title insurance agency licensed to issue title insurance with First American Title Insurance Company within South Carolina.</p>
+        <div class="job">
+          <h4>POHL Talent Management, LLC (dba POHL Talent) — Manager • 2018–Present</h4>
+          <p>Established a small talent agency representing musicians, writers, actors, athletes, and other performers.</p>
+        </div>
 
-      <h4>POHL Talent Management, LLC (dba POHL Talent) — Manager • 2018–Present</h4>
-      <p>Established a small talent agency representing musicians, writers, actors, athletes, and other performers.</p>
+        <div class="job">
+          <h4>POHL Property Management, LLC — Manager &amp; Sole Member • 2012–2013</h4>
+          <p>Established, managed and sold a property management business that managed residential and commercial property including, but not limited to, investment homes, a bar, a restaurant, and a hotel.</p>
+        </div>
 
-      <h4>POHL Property Management, LLC — Manager &amp; Sole Member • 2012–2013</h4>
-      <p>Established, managed and sold a property management business that managed residential and commercial property including, but not limited to, investment homes, a bar, a restaurant, and a hotel.</p>
+        <div class="job">
+          <h4>Stodghill Law Firm Chartered — Associate • 2011–2012</h4>
+          <p>Performed the same duties and responsibilities as Corporate Bankruptcy Associate for The Cooper Law Firm.</p>
+        </div>
 
-      <h4>Stodghill Law Firm Chartered — Associate • 2011–2012</h4>
-      <p>Performed the same duties and responsibilities as Corporate Bankruptcy Associate for The Cooper Law Firm.</p>
+        <div class="job">
+          <h4>The Cooper Law Firm — Corporate Bankruptcy Associate • 2010–2011</h4>
+          <p>Interviewed, negotiated, and managed individuals and businesses in restructuring debt and monetizing assets by obtaining financing, restructuring liabilities and, if necessary, filing bankruptcy as a Chapter 7 equity buyout or Chapter 11 reorganization.</p>
+          <p>Drafted, filed and argued adversarial proceedings, motions, applications, settlements, disclosure statements, plans, objections, responses and all other matters before the U.S. Bankruptcy Court.</p>
+          <p>Negotiated and drafted compromises and settlement offers with federal and state taxing authorities.</p>
+          <p>Litigated adverse proceedings including conducting depositions, drafting interrogatories, subpoenas, and all other forms of discovery.</p>
+        </div>
 
-      <h4>The Cooper Law Firm — Corporate Bankruptcy Associate • 2010–2011</h4>
-      <p>Interviewed, negotiated, and managed individuals and businesses in restructuring debt and monetizing assets by obtaining financing, restructuring liabilities and, if necessary, filing bankruptcy as a Chapter 7 equity buyout or Chapter 11 reorganization.</p>
-      <p>Drafted, filed and argued adversarial proceedings, motions, applications, settlements, disclosure statements, plans, objections, responses and all other matters before the U.S. Bankruptcy Court.</p>
-      <p>Negotiated and drafted compromises and settlement offers with federal and state taxing authorities.</p>
-      <p>Litigated adverse proceedings including conducting depositions, drafting interrogatories, subpoenas, and all other forms of discovery.</p>
+        <div class="job">
+          <h4>Resurgent Capital Services, LP — Manager, Legal Services Compliance • 2009–2010</h4>
+          <p>Analyzed distressed asset portfolios secured by real estate (commercial and residential), personal property and/or intangible property—portfolios ranged from $2MM–$500MM.</p>
+          <p>Developed litigation and liquidation plans to maximize recovery through foreclosure, repossession, insurance claims, subrogation claims, indemnification claims, fraud claims and contract claims, generating maximum recoveries on government‑insured, privately insured, non‑conforming, conforming, secured and unsecured loans.</p>
+          <p>Managed bankruptcy litigation, foreclosure and international mortgage servicing departments overseeing secured accounts throughout the U.S., Canada, Bahamas, Mexico, and Dominican Republic, including claims filing, motions for relief from stay, claim objections, lien strips, §523 actions, reaffirmations, settlements, loan mods, forbearances, mediations, depositions, stay‑violation issues, notices of default, substitutions of trustee, trustee sale notices, trustee sales, publications of sale, TILA/RESPA claims, bidding instructions, deficiency claims filing, wage and bank account garnishments, judgment liens and related matters.</p>
+        </div>
 
-      <h4>Resurgent Capital Services, LP — Manager, Legal Services Compliance • 2009–2010</h4>
-      <p>Analyzed distressed asset portfolios secured by real estate (commercial and residential), personal property and/or intangible property—portfolios ranged from $2MM–$500MM.</p>
-      <p>Developed litigation and liquidation plans to maximize recovery through foreclosure, repossession, insurance claims, subrogation claims, indemnification claims, fraud claims and contract claims, generating maximum recoveries on government‑insured, privately insured, non‑conforming, conforming, secured and unsecured loans.</p>
-      <p>Managed bankruptcy litigation, foreclosure and international mortgage servicing departments overseeing secured accounts throughout the U.S., Canada, Bahamas, Mexico, and Dominican Republic, including claims filing, motions for relief from stay, claim objections, lien strips, §523 actions, reaffirmations, settlements, loan mods, forbearances, mediations, depositions, stay‑violation issues, notices of default, substitutions of trustee, trustee sale notices, trustee sales, publications of sale, TILA/RESPA claims, bidding instructions, deficiency claims filing, wage and bank account garnishments, judgment liens and related matters.</p>
+        <div class="job">
+          <h4>Fell, Marking, Abkin, Montgomery, Granet &amp; Raney, LLP — Associate • 2008–2009</h4>
+          <p>Designed, produced and presented formation documents (PPMs, offering circulars, investor questionnaires, subscription agreements, articles, operating agreements, bylaws, minutes, stock certificates), federal and state licensing applications and related documentation to establish and finance businesses.</p>
+          <p>Drafted legal memos, briefs, opinions and research related to taxes, liability, insurance, real property, land use and other legal matters.</p>
+        </div>
 
-      <h4>Fell, Marking, Abkin, Montgomery, Granet &amp; Raney, LLP — Associate • 2008–2009</h4>
-      <p>Designed, produced and presented formation documents (PPMs, offering circulars, investor questionnaires, subscription agreements, articles, operating agreements, bylaws, minutes, stock certificates), federal and state licensing applications and related documentation to establish and finance businesses.</p>
-      <p>Drafted legal memos, briefs, opinions and research related to taxes, liability, insurance, real property, land use and other legal matters.</p>
+        <div class="job">
+          <h4>Quality Loans, LLC — General Counsel, Executive Managing Director • 2007–2008</h4>
+          <p>Established a Delaware LLC to acquire/finance/establish a nationally chartered bank or broker‑dealer and to acquire, sell, securitize, broker, originate and trade mortgage loans and similar instruments.</p>
+          <p>Drafted and filed formation documents including PPM, state/federal applications and all materials required to be licensed to originate, sell, purchase and securitize financial instruments.</p>
+          <p>Negotiated leases, software agreements and other documentation; set up payroll, health benefits and company functions.</p>
+          <p>Raised $25.5MM in startup capital; drafted/negotiated credit lines for $250MM to finance acquisitions, originations and securitizations.</p>
+        </div>
 
-      <h4>Quality Loans, LLC — General Counsel, Executive Managing Director • 2007–2008</h4>
-      <p>Established a Delaware LLC to acquire/finance/establish a nationally chartered bank or broker‑dealer and to acquire, sell, securitize, broker, originate and trade mortgage loans and similar instruments.</p>
-      <p>Drafted and filed formation documents including PPM, state/federal applications and all materials required to be licensed to originate, sell, purchase and securitize financial instruments.</p>
-      <p>Negotiated leases, software agreements and other documentation; set up payroll, health benefits and company functions.</p>
-      <p>Raised $25.5MM in startup capital; drafted/negotiated credit lines for $250MM to finance acquisitions, originations and securitizations.</p>
+        <div class="job">
+          <h4>Quality Home Loans — General Counsel, Executive Managing Director • 2006–2007</h4>
+          <p>Created and managed legal, correspondent and capital‑markets divisions completing ~$1B in mortgage originations, $1B in securities and purchasing ~$250MM of whole loans annually.</p>
+          <p>Developed marketing/sales strategy securing $30MM/month in correspondent purchases.</p>
+          <p>Drafted offering materials and related documents to raise $60MM in private equity and $50MM in short‑term commercial paper; established $300MM in credit facilities with hedge funds, national banks and institutional investors.</p>
+          <p>Managed four private equity funds ($60MM), three warehouse lines ($300MM) and seven securities averaging $150MM each.</p>
+          <p>Implemented compliance procedures; negotiated vendor agreements; advised senior management on HR, foreclosures, evictions, leases, acquisitions, mergers and reorganizations; coordinated four Chapter 11 and one Chapter 7 bankruptcies.</p>
+        </div>
 
-      <h4>Quality Home Loans — General Counsel, Executive Managing Director • 2006–2007</h4>
-      <p>Created and managed legal, correspondent and capital‑markets divisions completing ~$1B in mortgage originations, $1B in securities and purchasing ~$250MM of whole loans annually.</p>
-      <p>Developed marketing/sales strategy securing $30MM/month in correspondent purchases.</p>
-      <p>Drafted offering materials and related documents to raise $60MM in private equity and $50MM in short‑term commercial paper; established $300MM in credit facilities with hedge funds, national banks and institutional investors.</p>
-      <p>Managed four private equity funds ($60MM), three warehouse lines ($300MM) and seven securities averaging $150MM each.</p>
-      <p>Implemented compliance procedures; negotiated vendor agreements; advised senior management on HR, foreclosures, evictions, leases, acquisitions, mergers and reorganizations; coordinated four Chapter 11 and one Chapter 7 bankruptcies.</p>
+        <div class="job">
+          <h4>Countrywide Home Loans, Inc. — First Vice President, Senior Legal Counsel • 2002–2006</h4>
+          <p>Managed attorneys/administrators to purchase, sell and securitize approximately $9B/month of mortgage loans.</p>
+          <p>Drafted/negotiated MLPA, indemnities, PSA, AARA, repurchase, servicing‑rights and related agreements; advised on underwriting, funding, servicing and title issues; developed compliance procedures; handled disputes; assisted in consumer‑finance litigation; monitored due diligence and compliance.</p>
+        </div>
 
-      <h4>Countrywide Home Loans, Inc. — First Vice President, Senior Legal Counsel • 2002–2006</h4>
-      <p>Managed attorneys/administrators to purchase, sell and securitize approximately $9B/month of mortgage loans.</p>
-      <p>Drafted/negotiated MLPA, indemnities, PSA, AARA, repurchase, servicing‑rights and related agreements; advised on underwriting, funding, servicing and title issues; developed compliance procedures; handled disputes; assisted in consumer‑finance litigation; monitored due diligence and compliance.</p>
+        <div class="job">
+          <h4>California Association of REALTORS&reg;, Inc. — Corporate Attorney • 2001–2002</h4>
+          <p>Prepared formation documents, acquired venture capital and advised officers/directors across nine entities.</p>
+          <p>Assisted in acquisitions/mergers; IP (copyrights, trademarks, patents); negotiated and drafted diverse contracts; administered employee equity plan; maintained entity records; ensured compliance with campaign and political laws for two PACs.</p>
+        </div>
 
-      <h4>California Association of REALTORS&reg;, Inc. — Corporate Attorney • 2001–2002</h4>
-      <p>Prepared formation documents, acquired venture capital and advised officers/directors across nine entities.</p>
-      <p>Assisted in acquisitions/mergers; IP (copyrights, trademarks, patents); negotiated and drafted diverse contracts; administered employee equity plan; maintained entity records; ensured compliance with campaign and political laws for two PACs.</p>
+        <div class="job">
+          <h4>KPMG, LLP — Senior Tax Specialist • 2000–2001</h4>
+          <p>Interpreted 12 state tax/corporate codes; devised plans decreasing taxes by 80%+.</p>
+          <p>Implemented tax‑minimization plans via reorganizations/reincorporations; negotiated incentives; prepared feasibility studies worth several million dollars.</p>
+          <p>Realized a $20MM tax refund by supervising the collection/processing/certification of information to eliminate sales/use tax using California Enterprise Zone Credits and Manufacturer’s Investment Credits.</p>
+        </div>
+      </div>
+    </div>
 
-      <h4>KPMG, LLP — Senior Tax Specialist • 2000–2001</h4>
-      <p>Interpreted 12 state tax/corporate codes; devised plans decreasing taxes by 80%+.</p>
-      <p>Implemented tax‑minimization plans via reorganizations/reincorporations; negotiated incentives; prepared feasibility studies worth several million dollars.</p>
-      <p>Realized a $20MM tax refund by supervising the collection/processing/certification of information to eliminate sales/use tax using California Enterprise Zone Credits and Manufacturer’s Investment Credits.</p>
-
-      <h3>Education</h3>
+    <div class="info-section">
+      <h2 class="section-title">Education</h2>
       <ul>
         <li>LL.M., Taxation (Cum Laude) — University of San Diego School of Law, 2000</li>
         <li>Juris Doctor — University of San Diego School of Law, 1999</li>
@@ -157,11 +193,15 @@
         <li>Baccalaureus Artium, English Literature — Boston College, 1991</li>
         <li>Merit Certificate, English Literature — Harris Manchester College, Oxford University, 1990</li>
       </ul>
+    </div>
 
-      <h3>Admissions &amp; Courts</h3>
+    <div class="info-section">
+      <h2 class="section-title">Admissions &amp; Courts</h2>
       <p>California (2000) • District of Columbia (2002) • Tennessee (2008) • North Carolina (2009) • South Carolina (2010) • United States Federal Courts (2000) • United States Tax Court (2000) • United States Supreme Court (2006) • United States Bankruptcy Court (2010).</p>
+    </div>
 
-      <h3>Additional Licenses</h3>
+    <div class="info-section">
+      <h2 class="section-title">Additional Licenses</h2>
       <ul>
         <li>Insurance Broker: South Carolina (2013)</li>
         <li>Real Estate Broker: South Carolina (2012)</li>

--- a/styles.css
+++ b/styles.css
@@ -386,6 +386,36 @@ h2 {
   }
 }
 
+.info-section {
+  max-width: 900px;
+  margin: 0 auto 2rem;
+  padding: 2rem 1.25rem;
+  background: #fff;
+  border-radius: 6px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+.contact-card {
+  background: var(--vi-gray);
+  padding: 1rem 1.5rem;
+  border-left: 4px solid var(--vi-gold);
+  margin-bottom: 1rem;
+}
+
+.experience .job {
+  margin-bottom: 1.5rem;
+}
+
+.experience .job h4 {
+  margin: 0 0 0.5rem;
+  font-family: "Merriweather", serif;
+  color: var(--vi-1);
+}
+
+.experience .job p {
+  margin: 0.25rem 0;
+}
+
 /* Testimonials */
 .testimonials {
   max-width: 900px;


### PR DESCRIPTION
## Summary
- Break about page into clear sections for contact details, professional summary, experience, and credentials
- Add CSS for card-style info sections and job listings to give page a refined look

## Testing
- `npx htmlhint about.html styles.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689674f51dcc83218354cc2a64ae81ce