### PR TITLE
Expand navigation bar to full width and unify about page layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -119,8 +119,7 @@ a:hover {
   padding: 0.75rem 1.25rem;
   border-bottom: 1px solid var(--vi-gold);
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
-  max-width: 1200px;
-  margin: 0 auto;
+  width: 100%;
 }
 .site-header nav a {
   color: #fff;
@@ -285,7 +284,7 @@ h2 {
   flex-direction: column;
   align-items: center;
   gap: 1.5rem;
-  max-width: 1000px;
+  max-width: 1100px;
   margin: 0 auto;
 }
 .about-wrapper img {
@@ -359,7 +358,7 @@ h2 {
   flex-direction: column;
   align-items: center;
   gap: 2rem;
-  max-width: 900px;
+  max-width: 1100px;
   margin: 0 auto;
 }
 .about-photo {
@@ -387,12 +386,9 @@ h2 {
 }
 
 .info-section {
-  max-width: 900px;
+  max-width: 1100px;
   margin: 0 auto 2rem;
   padding: 2rem 1.25rem;
-  background: #fff;
-  border-radius: 6px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
 }
 
 .contact-card {


### PR DESCRIPTION
## Summary
- Extend site navigation to span the full viewport width.
- Increase about page content width and remove card-style boxes so sections match home page layout.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68967fa73950832188e4916ae7820f38