### PR TITLE
Ensure navigation and about page span full width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -119,8 +119,7 @@ a:hover {
   padding: 0.75rem 1.25rem;
   border-bottom: 1px solid var(--vi-gold);
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
-  max-width: 1200px;
-  margin: 0 auto;
+  width: 100%;
 }
 .site-header nav a {
   color: #fff;
@@ -285,7 +284,7 @@ h2 {
   flex-direction: column;
   align-items: center;
   gap: 1.5rem;
-  max-width: 1000px;
+  max-width: 1200px;
   margin: 0 auto;
 }
 .about-wrapper img {
@@ -359,7 +358,7 @@ h2 {
   flex-direction: column;
   align-items: center;
   gap: 2rem;
-  max-width: 900px;
+  max-width: 1200px;
   margin: 0 auto;
 }
 .about-photo {
@@ -387,7 +386,7 @@ h2 {
 }
 
 .info-section {
-  max-width: 900px;
+  max-width: 1200px;
   margin: 0 auto 2rem;
   padding: 2rem 1.25rem;
   background: #fff;


### PR DESCRIPTION
## Summary
- Make header background stretch full width on all pages
- Align About page sections with sitewide layout by increasing wrapper widths

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68967fa73950832188e4916ae7820f38