### PR TITLE
Add Cloudflare icons and social metadata

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,13 +3,19 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" href="images/favicon.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
+  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
+  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
+  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" />
+  <link rel="manifest" href="site.webmanifest" />
   <meta name="description" content="Learn about Attorney Robert Pohl and how our firm helps Virgin Islanders find financial relief under Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="About | VI Bankruptcy" />
   <meta property="og:description" content="Learn about Attorney Robert Pohl and how our firm helps Virgin Islanders find financial relief under Chapters 7, 11, 12 &amp; 13." />
-  <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
+  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/about.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/about.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
@@ -28,7 +34,7 @@
 <body>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>
@@ -59,7 +65,7 @@
   <section class="bg-white" id="about">
     <h2 class="section-title">About Us</h2>
     <div class="about-wrapper">
-      <img class="about-photo" src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/robert-pohl-headshot/public" alt="Robert A. Pohl smiling in his office" />
+      <img class="about-photo" src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public" alt="Pencil drawing of attorney Robert A. Pohl" />
       <div class="about-text">
         <h3 class="about-heading">Robert A. Pohl – Bankruptcy Attorney</h3>
         <p>Robert A. Pohl is a seasoned bankruptcy attorney holding a J.D., LL.M. in Tax, and an MBA. Admitted in the U.S. Virgin Islands and multiple states, he has spent more than 25&nbsp;years helping individuals and businesses overcome debt.</p>

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -3,13 +3,19 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" href="images/favicon.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
+  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
+  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
+  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" />
+  <link rel="manifest" href="site.webmanifest" />
   <meta name="description" content="Support for Virgin Islands businesses through Chapter 7, 11, 12 &amp; 13 solutions, including Subchapter V." />
   <meta property="og:title" content="Business Bankruptcy | VI Bankruptcy" />
   <meta property="og:description" content="Support for Virgin Islands businesses through Chapter 7, 11, 12 &amp; 13 solutions, including Subchapter V." />
-  <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
+  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/business-bankruptcy.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/business-bankruptcy.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
@@ -28,7 +34,7 @@
 <body>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>

--- a/contact.html
+++ b/contact.html
@@ -3,13 +3,19 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" href="images/favicon.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
+  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
+  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
+  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" />
+  <link rel="manifest" href="site.webmanifest" />
   <meta name="description" content="Contact POHL BANKRUPTCY, LLC for a free bankruptcy consultation in the Virgin Islands covering Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Contact | VI Bankruptcy" />
   <meta property="og:description" content="Contact POHL BANKRUPTCY, LLC for a free bankruptcy consultation in the Virgin Islands covering Chapters 7, 11, 12 &amp; 13." />
-  <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
+  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/contact.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/contact.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
@@ -28,7 +34,7 @@
 <body>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -3,13 +3,19 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" href="images/favicon.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
+  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
+  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
+  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" />
+  <link rel="manifest" href="site.webmanifest" />
   <meta name="description" content="Legal disclaimer for viBankruptcy.com and POHL BANKRUPTCY, LLC regarding Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Disclaimer | VI Bankruptcy" />
   <meta property="og:description" content="Legal disclaimer for viBankruptcy.com and POHL BANKRUPTCY, LLC regarding Chapters 7, 11, 12 &amp; 13." />
-  <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
+  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/disclaimer.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/disclaimer.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
@@ -28,7 +34,7 @@
 <body>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>

--- a/faq.html
+++ b/faq.html
@@ -3,13 +3,19 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" href="images/favicon.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
+  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
+  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
+  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" />
+  <link rel="manifest" href="site.webmanifest" />
   <meta name="description" content="Answers to common bankruptcy questions for individuals and businesses in the Virgin Islands, including Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Bankruptcy FAQ | VI Bankruptcy" />
   <meta property="og:description" content="Answers to common bankruptcy questions for individuals and businesses in the Virgin Islands, including Chapters 7, 11, 12 &amp; 13." />
-  <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
+  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/faq.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/faq.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
@@ -28,7 +34,7 @@
 <body>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>

--- a/index.html
+++ b/index.html
@@ -3,13 +3,19 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" href="images/favicon.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
+  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
+  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
+  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" />
+  <link rel="manifest" href="site.webmanifest" />
   <meta name="description" content="Experienced Virgin Islands bankruptcy attorney offering personal and business debt relief under Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="VI Bankruptcy | Virgin Islands Debt Relief Attorney" />
   <meta property="og:description" content="Experienced Virgin Islands bankruptcy attorney offering personal and business debt relief under Chapters 7, 11, 12 &amp; 13." />
-  <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
+  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/index.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/index.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
@@ -28,7 +34,7 @@
 <body>
   <header class="site-header">
     <a href="index.html" class="logo-link">
-      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" alt="VI Bankruptcy icon" />
       <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>

--- a/pay-online.html
+++ b/pay-online.html
@@ -3,13 +3,19 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" href="images/favicon.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
+  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
+  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
+  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" />
+  <link rel="manifest" href="site.webmanifest" />
   <meta name="description" content="Secure online payment portal for clients of POHL BANKRUPTCY, LLC handling Chapter 7, 11, 12 &amp; 13 matters." />
   <meta property="og:title" content="Pay Online | VI Bankruptcy" />
   <meta property="og:description" content="Secure online payment portal for clients of POHL BANKRUPTCY, LLC handling Chapter 7, 11, 12 &amp; 13 matters." />
-  <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
+  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/pay-online.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/pay-online.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
@@ -28,7 +34,7 @@
 <body>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -3,13 +3,19 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" href="images/favicon.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
+  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
+  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
+  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" />
+  <link rel="manifest" href="site.webmanifest" />
   <meta name="description" content="Guidance on Chapters 7, 11, 12 &amp; 13 personal bankruptcy for Virgin Islands residents." />
   <meta property="og:title" content="Personal Bankruptcy | VI Bankruptcy" />
   <meta property="og:description" content="Guidance on Chapters 7, 11, 12 &amp; 13 personal bankruptcy for Virgin Islands residents." />
-  <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
+  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/personal-bankruptcy.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/personal-bankruptcy.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
@@ -32,8 +38,8 @@
     <header class="site-header">
         <a href="index.html" class="logo-link">
           <img
-            src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public"
-            alt="viBankruptcy logo"
+            src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public"
+            alt="VI Bankruptcy icon"
           />
           <span class="logo-text">Pohl Bankruptcy</span>
         </a>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -3,13 +3,19 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" href="images/favicon.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
+  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
+  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
+  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" />
+  <link rel="manifest" href="site.webmanifest" />
   <meta name="description" content="Privacy practices of viBankruptcy.com and POHL BANKRUPTCY, LLC for Chapter 7, 11, 12 &amp; 13 services." />
   <meta property="og:title" content="Privacy Policy | VI Bankruptcy" />
   <meta property="og:description" content="Privacy practices of viBankruptcy.com and POHL BANKRUPTCY, LLC for Chapter 7, 11, 12 &amp; 13 services." />
-  <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
+  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/privacy-policy.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/privacy-policy.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
@@ -28,7 +34,7 @@
 <body>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -3,13 +3,19 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" href="images/favicon.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
+  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
+  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
+  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" />
+  <link rel="manifest" href="site.webmanifest" />
   <meta name="description" content="Checklist of documents to prepare when filing bankruptcy with POHL BANKRUPTCY, LLC for Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Ready to File? Checklist | VI Bankruptcy" />
   <meta property="og:description" content="Checklist of documents to prepare when filing bankruptcy with POHL BANKRUPTCY, LLC for Chapters 7, 11, 12 &amp; 13." />
-  <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
+  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/ready-to-file.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/ready-to-file.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
@@ -28,7 +34,7 @@
 <body>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "Pohl Bankruptcy",
+  "short_name": "VI Bankruptcy",
+  "icons": [
+    {
+      "src": "https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#132326",
+  "background_color": "#132326",
+  "display": "standalone"
+}

--- a/testimonials.html
+++ b/testimonials.html
@@ -3,13 +3,19 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" href="images/favicon.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
+  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
+  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
+  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" />
+  <link rel="manifest" href="site.webmanifest" />
   <meta name="description" content="Read testimonials from clients of POHL BANKRUPTCY, LLC in the Virgin Islands for Chapters 7, 11, 12 &amp; 13 cases." />
   <meta property="og:title" content="Testimonials | VI Bankruptcy" />
   <meta property="og:description" content="Read testimonials from clients of POHL BANKRUPTCY, LLC in the Virgin Islands for Chapters 7, 11, 12 &amp; 13 cases." />
-  <meta property="og:image" content="https://vibankruptcy.com/images/favicon.png" />
+  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/testimonials.html" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/testimonials.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
@@ -28,7 +34,7 @@
 <body>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="viBankruptcy logo" />
+        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn">☰ Menu</button>


### PR DESCRIPTION
## Summary
- Serve favicon and app icons from Cloudflare Images and add site manifest
- Use Cloudflare-hosted Open Graph and Twitter preview images across all pages
- Update about page with new headshot illustration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68969310c2b083219a33e9dbaed8f425