### PR TITLE
Add dimensions to about page photo

### DIFF
--- a/about.html
+++ b/about.html
@@ -65,7 +65,7 @@
   <section class="bg-white" id="about">
     <h2 class="section-title">About Us</h2>
     <div class="about-wrapper">
-      <img class="about-photo" src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public" alt="Pencil drawing of attorney Robert A. Pohl" />
+      <img class="about-photo" src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public" alt="Pencil drawing of attorney Robert A. Pohl" width="1024" height="1024" />
       <div class="about-text">
         <h3 class="about-heading">Robert A. Pohl – Bankruptcy Attorney</h3>
         <p>Robert A. Pohl is a seasoned bankruptcy attorney holding a J.D., LL.M. in Tax, and an MBA. Admitted in the U.S. Virgin Islands and multiple states, he has spent more than 25&nbsp;years helping individuals and businesses overcome debt.</p>


### PR DESCRIPTION
## Summary
- Specify width and height on about-page portrait image to reduce layout shifts

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -I https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6896961b2aac8321b14d8f1e2c15e7fa