### PR TITLE
Fix stretching on about page image

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -371,6 +371,7 @@ h2 {
 }
 .about-photo {
   width: 100%;
+  height: auto;
   margin: 0;
   max-width: 240px;
   border-radius: 6px;


### PR DESCRIPTION
## Summary
- prevent about page portrait from stretching by letting its height scale with width

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68969cc3fb4483218742e591375775cc