### PR TITLE
Fix navigation overflow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,8 @@
+/* Ensure padding and borders are included in element width */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 :root {
   --vi-1: #1b3940; /* Deep Teal */
   --vi-2: #132326; /* Midnight */


### PR DESCRIPTION
## Summary
- Ensure elements include padding and borders in their width to prevent navigation overflow

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6896a23cb9148321ad940c777bace057