### PR TITLE
Improve mobile navigation with icon-based menu

### DIFF
--- a/about.html
+++ b/about.html
@@ -38,9 +38,9 @@
         <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
-    <button id="menu-toggle" class="btn">☰ Menu</button>
+    <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>
     <nav>
-      <a href="about.html">About</a>
+      <a href="about.html" data-icon="ℹ️">About</a>
       <div class="dropdown">
         <a href="index.html#services">Services ▾</a>
         <div class="dropdown-content">
@@ -48,10 +48,12 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
-      <a href="testimonials.html">Testimonials</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-      <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
+      <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
+      <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="testimonials.html" data-icon="💬">Testimonials</a>
+      <a href="faq.html" data-icon="❓">FAQ</a>
+      <a href="contact.html" data-icon="✉️">Contact</a>
+      <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
     </nav>
   </header>
 
@@ -239,9 +241,18 @@
   </footer>
 
 <script>
-  document.getElementById('menu-toggle').onclick = function() {
-    document.querySelector('header nav').classList.toggle('open');
-  };
+  const menuToggle = document.getElementById('menu-toggle');
+  const nav = document.querySelector('header nav');
+  menuToggle.addEventListener('click', () => {
+    const open = nav.classList.toggle('open');
+    menuToggle.setAttribute('aria-expanded', open);
+  });
+  nav.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => {
+      nav.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+    });
+  });
 </script>
 
 </body>

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -37,7 +37,7 @@
     </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>
     <nav>
-      <a href="about.html">About</a>
+      <a href="about.html" data-icon="ℹ️">About</a>
       <div class="dropdown">
         <a href="index.html#services">Services ▾</a>
         <div class="dropdown-content">
@@ -45,11 +45,13 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
-      <a href="testimonials.html">Testimonials</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-      <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
-  </nav>
+      <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
+      <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="testimonials.html" data-icon="💬">Testimonials</a>
+      <a href="faq.html" data-icon="❓">FAQ</a>
+      <a href="contact.html" data-icon="✉️">Contact</a>
+      <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
+    </nav>
   </header>
 
   <nav class="breadcrumb" aria-label="Breadcrumb">
@@ -209,14 +211,19 @@
   </footer>
 
   <script>
-    const menuToggle = document.getElementById('menu-toggle');
-    menuToggle.addEventListener('click', function () {
-      const nav = document.querySelector('header nav');
-      const expanded = this.getAttribute('aria-expanded') === 'true';
-      this.setAttribute('aria-expanded', (!expanded).toString());
-      nav.classList.toggle('open');
+  const menuToggle = document.getElementById('menu-toggle');
+  const nav = document.querySelector('header nav');
+  menuToggle.addEventListener('click', () => {
+    const open = nav.classList.toggle('open');
+    menuToggle.setAttribute('aria-expanded', open);
+  });
+  nav.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => {
+      nav.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
     });
-    </script>
+  });
+</script>
 
     <script type="application/ld+json">
     {

--- a/contact.html
+++ b/contact.html
@@ -38,9 +38,9 @@
         <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
-    <button id="menu-toggle" class="btn">☰ Menu</button>
+    <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>
     <nav>
-      <a href="about.html">About</a>
+      <a href="about.html" data-icon="ℹ️">About</a>
       <div class="dropdown">
         <a href="index.html#services">Services ▾</a>
         <div class="dropdown-content">
@@ -48,10 +48,12 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
-      <a href="testimonials.html">Testimonials</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-      <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
+      <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
+      <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="testimonials.html" data-icon="💬">Testimonials</a>
+      <a href="faq.html" data-icon="❓">FAQ</a>
+      <a href="contact.html" data-icon="✉️">Contact</a>
+      <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
     </nav>
   </header>
 
@@ -125,9 +127,18 @@
   </script>
 
 <script>
-  document.getElementById('menu-toggle').onclick = function() {
-    document.querySelector('header nav').classList.toggle('open');
-  };
+  const menuToggle = document.getElementById('menu-toggle');
+  const nav = document.querySelector('header nav');
+  menuToggle.addEventListener('click', () => {
+    const open = nav.classList.toggle('open');
+    menuToggle.setAttribute('aria-expanded', open);
+  });
+  nav.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => {
+      nav.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+    });
+  });
 </script>
 
 </body>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -38,9 +38,9 @@
         <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
-    <button id="menu-toggle" class="btn">☰ Menu</button>
+    <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>
     <nav>
-      <a href="about.html">About</a>
+      <a href="about.html" data-icon="ℹ️">About</a>
       <div class="dropdown">
         <a href="index.html#services">Services ▾</a>
         <div class="dropdown-content">
@@ -48,10 +48,12 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
-      <a href="testimonials.html">Testimonials</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-      <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
+      <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
+      <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="testimonials.html" data-icon="💬">Testimonials</a>
+      <a href="faq.html" data-icon="❓">FAQ</a>
+      <a href="contact.html" data-icon="✉️">Contact</a>
+      <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
     </nav>
   </header>
 
@@ -79,9 +81,18 @@
   </footer>
 
 <script>
-  document.getElementById('menu-toggle').onclick = function() {
-    document.querySelector('header nav').classList.toggle('open');
-  };
+  const menuToggle = document.getElementById('menu-toggle');
+  const nav = document.querySelector('header nav');
+  menuToggle.addEventListener('click', () => {
+    const open = nav.classList.toggle('open');
+    menuToggle.setAttribute('aria-expanded', open);
+  });
+  nav.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => {
+      nav.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+    });
+  });
 </script>
 
 </body>

--- a/faq.html
+++ b/faq.html
@@ -38,9 +38,9 @@
         <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
-    <button id="menu-toggle" class="btn">☰ Menu</button>
+    <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>
     <nav>
-      <a href="about.html">About</a>
+      <a href="about.html" data-icon="ℹ️">About</a>
       <div class="dropdown">
         <a href="index.html#services">Services ▾</a>
         <div class="dropdown-content">
@@ -48,10 +48,12 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
-      <a href="testimonials.html">Testimonials</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-      <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
+      <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
+      <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="testimonials.html" data-icon="💬">Testimonials</a>
+      <a href="faq.html" data-icon="❓">FAQ</a>
+      <a href="contact.html" data-icon="✉️">Contact</a>
+      <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
     </nav>
   </header>
 
@@ -104,9 +106,18 @@
   </footer>
 
 <script>
-  document.getElementById('menu-toggle').onclick = function() {
-    document.querySelector('header nav').classList.toggle('open');
-  };
+  const menuToggle = document.getElementById('menu-toggle');
+  const nav = document.querySelector('header nav');
+  menuToggle.addEventListener('click', () => {
+    const open = nav.classList.toggle('open');
+    menuToggle.setAttribute('aria-expanded', open);
+  });
+  nav.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => {
+      nav.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+    });
+  });
 </script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -38,9 +38,9 @@
       <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
       <span class="logo-text">Pohl Bankruptcy</span>
     </a>
-    <button id="menu-toggle" class="btn">☰ Menu</button>
+    <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>
     <nav>
-      <a href="about.html">About</a>
+      <a href="about.html" data-icon="ℹ️">About</a>
       <div class="dropdown">
         <a href="index.html#services">Services ▾</a>
         <div class="dropdown-content">
@@ -48,10 +48,12 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
-      <a href="testimonials.html">Testimonials</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-      <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
+      <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
+      <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="testimonials.html" data-icon="💬">Testimonials</a>
+      <a href="faq.html" data-icon="❓">FAQ</a>
+      <a href="contact.html" data-icon="✉️">Contact</a>
+      <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
     </nav>
   </header>
 
@@ -164,9 +166,18 @@
   </footer>
 
 <script>
-  document.getElementById('menu-toggle').onclick = function() {
-    document.querySelector('header nav').classList.toggle('open');
-  };
+  const menuToggle = document.getElementById('menu-toggle');
+  const nav = document.querySelector('header nav');
+  menuToggle.addEventListener('click', () => {
+    const open = nav.classList.toggle('open');
+    menuToggle.setAttribute('aria-expanded', open);
+  });
+  nav.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => {
+      nav.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+    });
+  });
 </script>
 
 </body>

--- a/pay-online.html
+++ b/pay-online.html
@@ -38,9 +38,9 @@
         <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
-    <button id="menu-toggle" class="btn">☰ Menu</button>
+    <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>
     <nav>
-      <a href="about.html">About</a>
+      <a href="about.html" data-icon="ℹ️">About</a>
       <div class="dropdown">
         <a href="index.html#services">Services ▾</a>
         <div class="dropdown-content">
@@ -48,10 +48,12 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
-      <a href="testimonials.html">Testimonials</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-      <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
+      <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
+      <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="testimonials.html" data-icon="💬">Testimonials</a>
+      <a href="faq.html" data-icon="❓">FAQ</a>
+      <a href="contact.html" data-icon="✉️">Contact</a>
+      <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
     </nav>
   </header>
 
@@ -80,9 +82,18 @@
   </footer>
 
 <script>
-  document.getElementById('menu-toggle').onclick = function() {
-    document.querySelector('header nav').classList.toggle('open');
-  };
+  const menuToggle = document.getElementById('menu-toggle');
+  const nav = document.querySelector('header nav');
+  menuToggle.addEventListener('click', () => {
+    const open = nav.classList.toggle('open');
+    menuToggle.setAttribute('aria-expanded', open);
+  });
+  nav.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => {
+      nav.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+    });
+  });
 </script>
 
 </body>

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -52,7 +52,7 @@
     </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>
     <nav>
-      <a href="about.html">About</a>
+      <a href="about.html" data-icon="ℹ️">About</a>
       <div class="dropdown">
         <a href="index.html#services">Services ▾</a>
         <div class="dropdown-content">
@@ -60,11 +60,13 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
-      <a href="testimonials.html">Testimonials</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-      <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
-  </nav>
+      <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
+      <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="testimonials.html" data-icon="💬">Testimonials</a>
+      <a href="faq.html" data-icon="❓">FAQ</a>
+      <a href="contact.html" data-icon="✉️">Contact</a>
+      <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
+    </nav>
   </header>
 
   <nav class="breadcrumb" aria-label="Breadcrumb">
@@ -216,14 +218,19 @@
   </footer>
 
   <script>
-    const menuToggle = document.getElementById('menu-toggle');
-    menuToggle.addEventListener('click', function () {
-      const nav = document.querySelector('header nav');
-      const expanded = this.getAttribute('aria-expanded') === 'true';
-      this.setAttribute('aria-expanded', (!expanded).toString());
-      nav.classList.toggle('open');
+  const menuToggle = document.getElementById('menu-toggle');
+  const nav = document.querySelector('header nav');
+  menuToggle.addEventListener('click', () => {
+    const open = nav.classList.toggle('open');
+    menuToggle.setAttribute('aria-expanded', open);
+  });
+  nav.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => {
+      nav.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
     });
-    </script>
+  });
+</script>
 
     <script type="application/ld+json">
     {

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -38,9 +38,9 @@
         <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
-    <button id="menu-toggle" class="btn">☰ Menu</button>
+    <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>
     <nav>
-      <a href="about.html">About</a>
+      <a href="about.html" data-icon="ℹ️">About</a>
       <div class="dropdown">
         <a href="index.html#services">Services ▾</a>
         <div class="dropdown-content">
@@ -48,10 +48,12 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
-      <a href="testimonials.html">Testimonials</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-      <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
+      <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
+      <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="testimonials.html" data-icon="💬">Testimonials</a>
+      <a href="faq.html" data-icon="❓">FAQ</a>
+      <a href="contact.html" data-icon="✉️">Contact</a>
+      <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
     </nav>
   </header>
 
@@ -79,9 +81,18 @@
   </footer>
 
 <script>
-  document.getElementById('menu-toggle').onclick = function() {
-    document.querySelector('header nav').classList.toggle('open');
-  };
+  const menuToggle = document.getElementById('menu-toggle');
+  const nav = document.querySelector('header nav');
+  menuToggle.addEventListener('click', () => {
+    const open = nav.classList.toggle('open');
+    menuToggle.setAttribute('aria-expanded', open);
+  });
+  nav.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => {
+      nav.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+    });
+  });
 </script>
 
 </body>

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -38,9 +38,9 @@
         <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
-    <button id="menu-toggle" class="btn">☰ Menu</button>
+    <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>
     <nav>
-      <a href="about.html">About</a>
+      <a href="about.html" data-icon="ℹ️">About</a>
       <div class="dropdown">
         <a href="index.html#services">Services ▾</a>
         <div class="dropdown-content">
@@ -48,10 +48,12 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
-      <a href="testimonials.html">Testimonials</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-      <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
+      <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
+      <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="testimonials.html" data-icon="💬">Testimonials</a>
+      <a href="faq.html" data-icon="❓">FAQ</a>
+      <a href="contact.html" data-icon="✉️">Contact</a>
+      <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
     </nav>
   </header>
 
@@ -102,9 +104,18 @@
   </footer>
 
 <script>
-  document.getElementById('menu-toggle').onclick = function() {
-    document.querySelector('header nav').classList.toggle('open');
-  };
+  const menuToggle = document.getElementById('menu-toggle');
+  const nav = document.querySelector('header nav');
+  menuToggle.addEventListener('click', () => {
+    const open = nav.classList.toggle('open');
+    menuToggle.setAttribute('aria-expanded', open);
+  });
+  nav.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => {
+      nav.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+    });
+  });
 </script>
 
 </body>

--- a/styles.css
+++ b/styles.css
@@ -503,6 +503,10 @@ blockquote cite {
   display: none;
 }
 
+.mobile-only {
+  display: none;
+}
+
 /* Pay Online link adjustments */
 .header-pay-link {
   margin-left: 1rem;
@@ -558,20 +562,47 @@ footer a {
   }
   .site-header nav {
     display: none;
-    flex-direction: column;
-    text-align: center;
-    width: 100%;
-    margin: 0;
   }
   .site-header nav.open {
     display: flex;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    background: var(--vi-nav);
+    flex-wrap: wrap;
+    justify-content: center;
+    align-content: flex-start;
+    padding: 4rem 1rem 1rem;
+    overflow-y: auto;
+    z-index: 1000;
   }
-  .site-header nav .dropdown:hover .dropdown-content {
+  .site-header nav a {
+    flex: 0 0 calc(50% - 2rem);
+    margin: 0.5rem;
+    padding: 1rem;
+    background: none;
+    border: 1px solid var(--vi-gold);
+    border-radius: 8px;
+    text-align: center;
+  }
+  .site-header nav a::before {
+    content: attr(data-icon);
+    display: block;
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+  }
+  .site-header nav a.header-pay-link {
+    background: var(--vi-gold);
+    color: #000;
+  }
+  .site-header nav .dropdown,
+  .site-header nav .dropdown-content {
     display: none;
   }
-  .site-header nav.open .dropdown-content {
-    display: block;
-    position: static;
+  .mobile-only {
+    display: flex;
   }
   #menu-toggle {
     display: block;

--- a/testimonials.html
+++ b/testimonials.html
@@ -38,9 +38,9 @@
         <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
-    <button id="menu-toggle" class="btn">☰ Menu</button>
+    <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>
     <nav>
-      <a href="about.html">About</a>
+      <a href="about.html" data-icon="ℹ️">About</a>
       <div class="dropdown">
         <a href="index.html#services">Services ▾</a>
         <div class="dropdown-content">
@@ -48,10 +48,12 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
-      <a href="testimonials.html">Testimonials</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-      <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
+      <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
+      <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="testimonials.html" data-icon="💬">Testimonials</a>
+      <a href="faq.html" data-icon="❓">FAQ</a>
+      <a href="contact.html" data-icon="✉️">Contact</a>
+      <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
     </nav>
   </header>
 
@@ -100,9 +102,18 @@
   </footer>
 
 <script>
-  document.getElementById('menu-toggle').onclick = function() {
-    document.querySelector('header nav').classList.toggle('open');
-  };
+  const menuToggle = document.getElementById('menu-toggle');
+  const nav = document.querySelector('header nav');
+  menuToggle.addEventListener('click', () => {
+    const open = nav.classList.toggle('open');
+    menuToggle.setAttribute('aria-expanded', open);
+  });
+  nav.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => {
+      nav.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+    });
+  });
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- Replace hamburger dropdown with full-screen mobile menu featuring large square buttons and icons
- Hide desktop-only Services dropdown on mobile and add direct Personal/Business bankruptcy links
- Enhance menu script to toggle overlay and close after selection

## Testing
- `npx --yes htmlhint *.html`


------
https://chatgpt.com/codex/tasks/task_e_6896ba87c7988321ac5d0702a5b0eb18