### PR TITLE
Add mobile navigation actions

### DIFF
--- a/about.html
+++ b/about.html
@@ -48,12 +48,16 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
+      <a href="index.html" class="mobile-only" data-icon="🏠">Home</a>
       <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
       <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="tel:+13402033333" class="mobile-only" data-icon="📞">Call Now</a>
+      <a href="#" class="mobile-only add-contact" data-icon="📇">Add Pohl Bankruptcy to My Contacts</a>
       <a href="testimonials.html" data-icon="💬">Testimonials</a>
       <a href="faq.html" data-icon="❓">FAQ</a>
       <a href="contact.html" data-icon="✉️">Contact</a>
       <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
+      <a href="#" class="mobile-only close-nav" data-icon="❌">Close</a>
     </nav>
   </header>
 
@@ -248,7 +252,23 @@
     menuToggle.setAttribute('aria-expanded', open);
   });
   nav.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
+    link.addEventListener('click', (e) => {
+      if (link.classList.contains('add-contact')) {
+        e.preventDefault();
+        const vCard = `BEGIN:VCARD\nVERSION:3.0\nFN:Pohl Bankruptcy\nORG:Pohl Bankruptcy, LLC\nTEL;TYPE=work,voice:+1-340-203-3333\nEMAIL:robert@pohlbankruptcy.com\nEND:VCARD`;
+        const blob = new Blob([vCard], { type: 'text/vcard' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'pohl-bankruptcy.vcf';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+      if (link.classList.contains('close-nav')) {
+        e.preventDefault();
+      }
       nav.classList.remove('open');
       menuToggle.setAttribute('aria-expanded', 'false');
     });

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -45,12 +45,16 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
+      <a href="index.html" class="mobile-only" data-icon="🏠">Home</a>
       <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
       <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="tel:+13402033333" class="mobile-only" data-icon="📞">Call Now</a>
+      <a href="#" class="mobile-only add-contact" data-icon="📇">Add Pohl Bankruptcy to My Contacts</a>
       <a href="testimonials.html" data-icon="💬">Testimonials</a>
       <a href="faq.html" data-icon="❓">FAQ</a>
       <a href="contact.html" data-icon="✉️">Contact</a>
       <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
+      <a href="#" class="mobile-only close-nav" data-icon="❌">Close</a>
     </nav>
   </header>
 
@@ -218,12 +222,28 @@
     menuToggle.setAttribute('aria-expanded', open);
   });
   nav.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
+    link.addEventListener('click', (e) => {
+      if (link.classList.contains('add-contact')) {
+        e.preventDefault();
+        const vCard = `BEGIN:VCARD\nVERSION:3.0\nFN:Pohl Bankruptcy\nORG:Pohl Bankruptcy, LLC\nTEL;TYPE=work,voice:+1-340-203-3333\nEMAIL:robert@pohlbankruptcy.com\nEND:VCARD`;
+        const blob = new Blob([vCard], { type: 'text/vcard' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'pohl-bankruptcy.vcf';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+      if (link.classList.contains('close-nav')) {
+        e.preventDefault();
+      }
       nav.classList.remove('open');
       menuToggle.setAttribute('aria-expanded', 'false');
     });
   });
-</script>
+  </script>
 
     <script type="application/ld+json">
     {

--- a/contact.html
+++ b/contact.html
@@ -48,12 +48,16 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
+      <a href="index.html" class="mobile-only" data-icon="🏠">Home</a>
       <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
       <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="tel:+13402033333" class="mobile-only" data-icon="📞">Call Now</a>
+      <a href="#" class="mobile-only add-contact" data-icon="📇">Add Pohl Bankruptcy to My Contacts</a>
       <a href="testimonials.html" data-icon="💬">Testimonials</a>
       <a href="faq.html" data-icon="❓">FAQ</a>
       <a href="contact.html" data-icon="✉️">Contact</a>
       <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
+      <a href="#" class="mobile-only close-nav" data-icon="❌">Close</a>
     </nav>
   </header>
 
@@ -134,7 +138,23 @@
     menuToggle.setAttribute('aria-expanded', open);
   });
   nav.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
+    link.addEventListener('click', (e) => {
+      if (link.classList.contains('add-contact')) {
+        e.preventDefault();
+        const vCard = `BEGIN:VCARD\nVERSION:3.0\nFN:Pohl Bankruptcy\nORG:Pohl Bankruptcy, LLC\nTEL;TYPE=work,voice:+1-340-203-3333\nEMAIL:robert@pohlbankruptcy.com\nEND:VCARD`;
+        const blob = new Blob([vCard], { type: 'text/vcard' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'pohl-bankruptcy.vcf';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+      if (link.classList.contains('close-nav')) {
+        e.preventDefault();
+      }
       nav.classList.remove('open');
       menuToggle.setAttribute('aria-expanded', 'false');
     });

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -48,12 +48,16 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
+      <a href="index.html" class="mobile-only" data-icon="🏠">Home</a>
       <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
       <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="tel:+13402033333" class="mobile-only" data-icon="📞">Call Now</a>
+      <a href="#" class="mobile-only add-contact" data-icon="📇">Add Pohl Bankruptcy to My Contacts</a>
       <a href="testimonials.html" data-icon="💬">Testimonials</a>
       <a href="faq.html" data-icon="❓">FAQ</a>
       <a href="contact.html" data-icon="✉️">Contact</a>
       <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
+      <a href="#" class="mobile-only close-nav" data-icon="❌">Close</a>
     </nav>
   </header>
 
@@ -88,7 +92,23 @@
     menuToggle.setAttribute('aria-expanded', open);
   });
   nav.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
+    link.addEventListener('click', (e) => {
+      if (link.classList.contains('add-contact')) {
+        e.preventDefault();
+        const vCard = `BEGIN:VCARD\nVERSION:3.0\nFN:Pohl Bankruptcy\nORG:Pohl Bankruptcy, LLC\nTEL;TYPE=work,voice:+1-340-203-3333\nEMAIL:robert@pohlbankruptcy.com\nEND:VCARD`;
+        const blob = new Blob([vCard], { type: 'text/vcard' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'pohl-bankruptcy.vcf';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+      if (link.classList.contains('close-nav')) {
+        e.preventDefault();
+      }
       nav.classList.remove('open');
       menuToggle.setAttribute('aria-expanded', 'false');
     });

--- a/faq.html
+++ b/faq.html
@@ -48,12 +48,16 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
+      <a href="index.html" class="mobile-only" data-icon="🏠">Home</a>
       <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
       <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="tel:+13402033333" class="mobile-only" data-icon="📞">Call Now</a>
+      <a href="#" class="mobile-only add-contact" data-icon="📇">Add Pohl Bankruptcy to My Contacts</a>
       <a href="testimonials.html" data-icon="💬">Testimonials</a>
       <a href="faq.html" data-icon="❓">FAQ</a>
       <a href="contact.html" data-icon="✉️">Contact</a>
       <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
+      <a href="#" class="mobile-only close-nav" data-icon="❌">Close</a>
     </nav>
   </header>
 
@@ -113,7 +117,23 @@
     menuToggle.setAttribute('aria-expanded', open);
   });
   nav.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
+    link.addEventListener('click', (e) => {
+      if (link.classList.contains('add-contact')) {
+        e.preventDefault();
+        const vCard = `BEGIN:VCARD\nVERSION:3.0\nFN:Pohl Bankruptcy\nORG:Pohl Bankruptcy, LLC\nTEL;TYPE=work,voice:+1-340-203-3333\nEMAIL:robert@pohlbankruptcy.com\nEND:VCARD`;
+        const blob = new Blob([vCard], { type: 'text/vcard' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'pohl-bankruptcy.vcf';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+      if (link.classList.contains('close-nav')) {
+        e.preventDefault();
+      }
       nav.classList.remove('open');
       menuToggle.setAttribute('aria-expanded', 'false');
     });

--- a/index.html
+++ b/index.html
@@ -48,12 +48,16 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
+      <a href="index.html" class="mobile-only" data-icon="🏠">Home</a>
       <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
       <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="tel:+13402033333" class="mobile-only" data-icon="📞">Call Now</a>
+      <a href="#" class="mobile-only add-contact" data-icon="📇">Add Pohl Bankruptcy to My Contacts</a>
       <a href="testimonials.html" data-icon="💬">Testimonials</a>
       <a href="faq.html" data-icon="❓">FAQ</a>
       <a href="contact.html" data-icon="✉️">Contact</a>
       <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
+      <a href="#" class="mobile-only close-nav" data-icon="❌">Close</a>
     </nav>
   </header>
 
@@ -173,7 +177,23 @@
     menuToggle.setAttribute('aria-expanded', open);
   });
   nav.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
+    link.addEventListener('click', (e) => {
+      if (link.classList.contains('add-contact')) {
+        e.preventDefault();
+        const vCard = `BEGIN:VCARD\nVERSION:3.0\nFN:Pohl Bankruptcy\nORG:Pohl Bankruptcy, LLC\nTEL;TYPE=work,voice:+1-340-203-3333\nEMAIL:robert@pohlbankruptcy.com\nEND:VCARD`;
+        const blob = new Blob([vCard], { type: 'text/vcard' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'pohl-bankruptcy.vcf';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+      if (link.classList.contains('close-nav')) {
+        e.preventDefault();
+      }
       nav.classList.remove('open');
       menuToggle.setAttribute('aria-expanded', 'false');
     });

--- a/pay-online.html
+++ b/pay-online.html
@@ -48,12 +48,16 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
+      <a href="index.html" class="mobile-only" data-icon="🏠">Home</a>
       <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
       <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="tel:+13402033333" class="mobile-only" data-icon="📞">Call Now</a>
+      <a href="#" class="mobile-only add-contact" data-icon="📇">Add Pohl Bankruptcy to My Contacts</a>
       <a href="testimonials.html" data-icon="💬">Testimonials</a>
       <a href="faq.html" data-icon="❓">FAQ</a>
       <a href="contact.html" data-icon="✉️">Contact</a>
       <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
+      <a href="#" class="mobile-only close-nav" data-icon="❌">Close</a>
     </nav>
   </header>
 
@@ -89,7 +93,23 @@
     menuToggle.setAttribute('aria-expanded', open);
   });
   nav.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
+    link.addEventListener('click', (e) => {
+      if (link.classList.contains('add-contact')) {
+        e.preventDefault();
+        const vCard = `BEGIN:VCARD\nVERSION:3.0\nFN:Pohl Bankruptcy\nORG:Pohl Bankruptcy, LLC\nTEL;TYPE=work,voice:+1-340-203-3333\nEMAIL:robert@pohlbankruptcy.com\nEND:VCARD`;
+        const blob = new Blob([vCard], { type: 'text/vcard' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'pohl-bankruptcy.vcf';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+      if (link.classList.contains('close-nav')) {
+        e.preventDefault();
+      }
       nav.classList.remove('open');
       menuToggle.setAttribute('aria-expanded', 'false');
     });

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -60,12 +60,16 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
+      <a href="index.html" class="mobile-only" data-icon="🏠">Home</a>
       <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
       <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="tel:+13402033333" class="mobile-only" data-icon="📞">Call Now</a>
+      <a href="#" class="mobile-only add-contact" data-icon="📇">Add Pohl Bankruptcy to My Contacts</a>
       <a href="testimonials.html" data-icon="💬">Testimonials</a>
       <a href="faq.html" data-icon="❓">FAQ</a>
       <a href="contact.html" data-icon="✉️">Contact</a>
       <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
+      <a href="#" class="mobile-only close-nav" data-icon="❌">Close</a>
     </nav>
   </header>
 
@@ -225,12 +229,28 @@
     menuToggle.setAttribute('aria-expanded', open);
   });
   nav.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
+    link.addEventListener('click', (e) => {
+      if (link.classList.contains('add-contact')) {
+        e.preventDefault();
+        const vCard = `BEGIN:VCARD\nVERSION:3.0\nFN:Pohl Bankruptcy\nORG:Pohl Bankruptcy, LLC\nTEL;TYPE=work,voice:+1-340-203-3333\nEMAIL:robert@pohlbankruptcy.com\nEND:VCARD`;
+        const blob = new Blob([vCard], { type: 'text/vcard' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'pohl-bankruptcy.vcf';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+      if (link.classList.contains('close-nav')) {
+        e.preventDefault();
+      }
       nav.classList.remove('open');
       menuToggle.setAttribute('aria-expanded', 'false');
     });
   });
-</script>
+  </script>
 
     <script type="application/ld+json">
     {

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -48,12 +48,16 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
+      <a href="index.html" class="mobile-only" data-icon="🏠">Home</a>
       <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
       <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="tel:+13402033333" class="mobile-only" data-icon="📞">Call Now</a>
+      <a href="#" class="mobile-only add-contact" data-icon="📇">Add Pohl Bankruptcy to My Contacts</a>
       <a href="testimonials.html" data-icon="💬">Testimonials</a>
       <a href="faq.html" data-icon="❓">FAQ</a>
       <a href="contact.html" data-icon="✉️">Contact</a>
       <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
+      <a href="#" class="mobile-only close-nav" data-icon="❌">Close</a>
     </nav>
   </header>
 
@@ -88,7 +92,23 @@
     menuToggle.setAttribute('aria-expanded', open);
   });
   nav.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
+    link.addEventListener('click', (e) => {
+      if (link.classList.contains('add-contact')) {
+        e.preventDefault();
+        const vCard = `BEGIN:VCARD\nVERSION:3.0\nFN:Pohl Bankruptcy\nORG:Pohl Bankruptcy, LLC\nTEL;TYPE=work,voice:+1-340-203-3333\nEMAIL:robert@pohlbankruptcy.com\nEND:VCARD`;
+        const blob = new Blob([vCard], { type: 'text/vcard' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'pohl-bankruptcy.vcf';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+      if (link.classList.contains('close-nav')) {
+        e.preventDefault();
+      }
       nav.classList.remove('open');
       menuToggle.setAttribute('aria-expanded', 'false');
     });

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -48,12 +48,16 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
+      <a href="index.html" class="mobile-only" data-icon="🏠">Home</a>
       <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
       <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="tel:+13402033333" class="mobile-only" data-icon="📞">Call Now</a>
+      <a href="#" class="mobile-only add-contact" data-icon="📇">Add Pohl Bankruptcy to My Contacts</a>
       <a href="testimonials.html" data-icon="💬">Testimonials</a>
       <a href="faq.html" data-icon="❓">FAQ</a>
       <a href="contact.html" data-icon="✉️">Contact</a>
       <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
+      <a href="#" class="mobile-only close-nav" data-icon="❌">Close</a>
     </nav>
   </header>
 
@@ -111,7 +115,23 @@
     menuToggle.setAttribute('aria-expanded', open);
   });
   nav.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
+    link.addEventListener('click', (e) => {
+      if (link.classList.contains('add-contact')) {
+        e.preventDefault();
+        const vCard = `BEGIN:VCARD\nVERSION:3.0\nFN:Pohl Bankruptcy\nORG:Pohl Bankruptcy, LLC\nTEL;TYPE=work,voice:+1-340-203-3333\nEMAIL:robert@pohlbankruptcy.com\nEND:VCARD`;
+        const blob = new Blob([vCard], { type: 'text/vcard' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'pohl-bankruptcy.vcf';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+      if (link.classList.contains('close-nav')) {
+        e.preventDefault();
+      }
       nav.classList.remove('open');
       menuToggle.setAttribute('aria-expanded', 'false');
     });

--- a/testimonials.html
+++ b/testimonials.html
@@ -48,12 +48,16 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
+      <a href="index.html" class="mobile-only" data-icon="🏠">Home</a>
       <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
       <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
+      <a href="tel:+13402033333" class="mobile-only" data-icon="📞">Call Now</a>
+      <a href="#" class="mobile-only add-contact" data-icon="📇">Add Pohl Bankruptcy to My Contacts</a>
       <a href="testimonials.html" data-icon="💬">Testimonials</a>
       <a href="faq.html" data-icon="❓">FAQ</a>
       <a href="contact.html" data-icon="✉️">Contact</a>
       <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
+      <a href="#" class="mobile-only close-nav" data-icon="❌">Close</a>
     </nav>
   </header>
 
@@ -109,7 +113,23 @@
     menuToggle.setAttribute('aria-expanded', open);
   });
   nav.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
+    link.addEventListener('click', (e) => {
+      if (link.classList.contains('add-contact')) {
+        e.preventDefault();
+        const vCard = `BEGIN:VCARD\nVERSION:3.0\nFN:Pohl Bankruptcy\nORG:Pohl Bankruptcy, LLC\nTEL;TYPE=work,voice:+1-340-203-3333\nEMAIL:robert@pohlbankruptcy.com\nEND:VCARD`;
+        const blob = new Blob([vCard], { type: 'text/vcard' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'pohl-bankruptcy.vcf';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+      if (link.classList.contains('close-nav')) {
+        e.preventDefault();
+      }
       nav.classList.remove('open');
       menuToggle.setAttribute('aria-expanded', 'false');
     });


### PR DESCRIPTION
## Summary
- Add mobile-only Home, Call Now, Add to Contacts, and Close links to navigation
- Generate downloadable vCard for easy contact saving on mobile devices
- Close mobile menu after interactions for a smoother experience

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896c33a5ef0832188293d0f3efffad5