### PR TITLE
Fix attorney profile image on bankruptcy pages

### DIFF
--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -163,7 +163,7 @@
   <section class="bg-gray">
     <h2 class="section-title">Attorney Profile</h2>
     <div class="attorney-card">
-      <img src="https://api.cloudflare.com/client/v4/accounts/9748736d8674bad21f5e685fa96db7cd/images/v1/9fbd2df4-ebb4-4047-4397-7f2d03f5e900" alt="Robert Pohl, Bankruptcy Attorney" loading="lazy" decoding="async" width="100" height="100" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public" alt="Robert Pohl, Bankruptcy Attorney" loading="lazy" decoding="async" width="100" height="100" />
       <div class="attorney-card__content">
         <h3>Work directly with Robert A. Pohl</h3>
         <ul class="styled-list">

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -169,7 +169,7 @@
   <section class="bg-gray">
     <h2 class="section-title">Attorney Profile</h2>
     <div class="attorney-card">
-      <img src="https://api.cloudflare.com/client/v4/accounts/9748736d8674bad21f5e685fa96db7cd/images/v1/9fbd2df4-ebb4-4047-4397-7f2d03f5e900" alt="Robert Pohl, Bankruptcy Attorney" loading="lazy" decoding="async" width="100" height="100" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public" alt="Robert Pohl, Bankruptcy Attorney" loading="lazy" decoding="async" width="100" height="100" />
       <div class="attorney-card__content">
         <h3>Work directly with Robert A. Pohl</h3>
         <ul class="styled-list">


### PR DESCRIPTION
## Summary
- use Cloudflare delivery URL for attorney profile image on personal and business bankruptcy pages

## Testing
- `curl -I https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public`
- `npx --yes htmlhint business-bankruptcy.html personal-bankruptcy.html`

------
https://chatgpt.com/codex/tasks/task_e_6896c82b7b6c8321904599dc51c41dbd