### PR TITLE
Add cotton paper background to Legal Experience section

### DIFF
--- a/about.html
+++ b/about.html
@@ -100,7 +100,7 @@
       <p>Bankruptcy and financial‑litigation attorney (practicing since 2000) serving individuals and businesses across the U.S. Virgin Islands through offices on St. Thomas, St. John, and St. Croix. Founder of POHL, P.A. and POHL Bankruptcy, LLC. Experience includes distressed debt, bankruptcy filings and litigation, tax litigation and planning, corporate and securities work, real estate, estate planning, and related matters.</p>
     </div>
 
-    <div class="info-section">
+    <div class="info-section cotton-paper">
       <h2 class="section-title">Legal Experience</h2>
       <div class="experience">
         <div class="job">

--- a/styles.css
+++ b/styles.css
@@ -414,6 +414,13 @@ h2 {
   padding: 2rem 1.25rem;
 }
 
+.cotton-paper {
+  background-color: #fdfcf9;
+  background-image: url('https://www.transparenttextures.com/patterns/paper-fibers.png');
+  border: 1px solid #e5e2d6;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
 .contact-card {
   background: var(--vi-gray);
   padding: 1rem 1.5rem;


### PR DESCRIPTION
## Summary
- style: add cotton paper texture and styling for Legal Experience section on about page

## Testing
- `npx prettier --check about.html styles.css` *(fails: code style issues found)*
- `npx htmlhint about.html`


------
https://chatgpt.com/codex/tasks/task_e_6896c9510b008321803ab1ee86714ac2