### PR TITLE
Fix attorney profile image aspect ratio

### DIFF
--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -163,7 +163,7 @@
   <section class="bg-gray">
     <h2 class="section-title">Attorney Profile</h2>
     <div class="attorney-card">
-      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public" alt="Robert Pohl, Bankruptcy Attorney" loading="lazy" decoding="async" width="100" height="100" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public" alt="Robert Pohl, Bankruptcy Attorney" loading="lazy" decoding="async" width="1366" height="768" />
       <div class="attorney-card__content">
         <h3>Work directly with Robert A. Pohl</h3>
         <ul class="styled-list">

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -169,7 +169,7 @@
   <section class="bg-gray">
     <h2 class="section-title">Attorney Profile</h2>
     <div class="attorney-card">
-      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public" alt="Robert Pohl, Bankruptcy Attorney" loading="lazy" decoding="async" width="100" height="100" />
+      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public" alt="Robert Pohl, Bankruptcy Attorney" loading="lazy" decoding="async" width="1366" height="768" />
       <div class="attorney-card__content">
         <h3>Work directly with Robert A. Pohl</h3>
         <ul class="styled-list">

--- a/styles.css
+++ b/styles.css
@@ -684,7 +684,7 @@ footer a {
 .hero-actions {margin-top:1rem;display:flex;gap:.5rem;flex-wrap:wrap;}
 
 .attorney-card {display:grid;grid-template-columns:100px 1fr;gap:1rem;align-items:center;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.1);padding:1rem;border-radius:8px;max-width:900px;margin:1rem 0;}
-.attorney-card img {width:100px;height:100px;object-fit:cover;border-radius:8px;}
+.attorney-card img {width:100%;height:auto;border-radius:8px;}
 .attorney-card__content h3 {margin:0 0 .5rem;}
 
 .compliance-note {max-width:1100px;margin:1rem auto 0;padding:0 1.25rem;color:var(--vi-5);font-size:.875rem;}


### PR DESCRIPTION
## Summary
- Preserve attorney photo's 16:9 ratio on personal and business bankruptcy pages to prevent cropping.
- Adjust global attorney-card styles to scale images proportionally instead of forcing square dimensions.

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896caecf7608321a95d666520d1289a