### PR TITLE
Polish About page styling and layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -85,27 +85,47 @@
     </div>
   </section>
 
-  <section class="bg-white" id="about">
+  <section class="bg-white pattern-bg" id="about">
     <h2 class="section-title">About Us</h2>
     <div class="about-wrapper">
       <img class="about-photo" src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/1ab4fdc6-aa8f-4845-1760-5d6bdbd1e300/public" alt="Pencil drawing of attorney Robert A. Pohl" width="1024" height="1024" />
       <div class="about-text">
-        <h3 class="about-heading">Robert A. Pohl – Bankruptcy Attorney</h3>
-        <p>Robert A. Pohl is a seasoned bankruptcy attorney holding a J.D., LL.M. in Tax, and an MBA. Admitted in the U.S. Virgin Islands and multiple states, he has spent more than 25&nbsp;years helping individuals and businesses overcome debt.</p>
-        <p>Each client is unique, and each situation is unique. The difference between good and amazing service is not only addressing the common problems but tailoring solutions to attend to each detail that is unique. I believe in taking the time to get to know each client and making sure that they are well taken care of.</p>
+        <h3 class="about-heading"><span class="name-highlight">Robert A. Pohl</span> – Bankruptcy Attorney</h3>
+        <div class="personal-statement">
+          <p>Robert A. Pohl is a seasoned bankruptcy attorney holding a J.D., LL.M. in Tax, and an MBA. Admitted in the U.S. Virgin Islands and multiple states, he has spent more than 25&nbsp;years helping individuals and businesses overcome debt.</p>
+          <p class="more-text">Each client is unique, and each situation is unique. The difference between good and amazing service is not only addressing the common problems but tailoring solutions to attend to each detail that is unique. I believe in taking the time to get to know each client and making sure that they are well taken care of.</p>
+          <button class="read-more" aria-expanded="false">Read more</button>
+        </div>
+        <blockquote class="pull-quote">Financial freedom starts with honest advice and tailored strategy.</blockquote>
+        <ul class="styled-list accomplishments">
+          <li>25+ years guiding clients through bankruptcy</li>
+          <li>Admitted in the U.S. Virgin Islands and multiple states</li>
+          <li>Advanced degrees in Law, Taxation and Business</li>
+        </ul>
       </div>
-  </div>
+    </div>
   </section>
   <section class="bg-white">
     <div class="info-section" id="contact-info">
       <h2 class="section-title">Contact</h2>
       <div class="contact-card">
-        <p><strong>U.S. Virgin Islands Offices</strong><br />
-        St. Thomas: 5316 Yacht Haven Grande, Suite N‑104, Box 30, St. Thomas, VI 00802<br />
-        St. John: 5000 Estate Enighed, P.O. Box 343, St. John, VI 00830<br />
-        St. Croix: 6002 Diamond Ruby, Suite 3, PMB 633, Christiansted, VI 00820</p>
-        <p>Phone: Office (340) 203‑3333 • Mobile (864) 361‑4827<br />
-        Email: <a href="mailto:Robert@POHLPA.com">Robert@POHLPA.com</a></p>
+        <p><strong>U.S. Virgin Islands Offices</strong></p>
+        <div class="contact-columns">
+          <div class="office">
+            <h4>St. Thomas</h4>
+            <p>5316 Yacht Haven Grande, Suite N‑104, Box 30<br />St. Thomas, VI 00802</p>
+          </div>
+          <div class="office">
+            <h4>St. John</h4>
+            <p>5000 Estate Enighed, P.O. Box 343<br />St. John, VI 00830</p>
+          </div>
+          <div class="office">
+            <h4>St. Croix</h4>
+            <p>6002 Diamond Ruby, Suite 3, PMB 633<br />Christiansted, VI 00820</p>
+          </div>
+        </div>
+        <p class="contact-phones"><span class="icon" aria-hidden="true">📞</span> Office (340) 203‑3333 • Mobile (864) 361‑4827</p>
+        <p class="contact-email"><span class="icon" aria-hidden="true">✉️</span> <a href="mailto:Robert@POHLPA.com">Robert@POHLPA.com</a></p>
       </div>
     </div>
 
@@ -286,6 +306,33 @@
       nav.classList.remove('open');
       menuToggle.setAttribute('aria-expanded', 'false');
     });
+  });
+
+  // Read more toggle
+  const readMoreBtn = document.querySelector('.read-more');
+  const moreText = document.querySelector('.more-text');
+  if (readMoreBtn && moreText) {
+    readMoreBtn.addEventListener('click', () => {
+      const expanded = readMoreBtn.getAttribute('aria-expanded') === 'true';
+      readMoreBtn.setAttribute('aria-expanded', (!expanded).toString());
+      moreText.classList.toggle('open');
+      readMoreBtn.textContent = expanded ? 'Read more' : 'Read less';
+    });
+  }
+
+  // Animate lists on scroll
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('in-view');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+
+  document.querySelectorAll('.styled-list li').forEach(item => {
+    item.classList.add('fade-in');
+    observer.observe(item);
   });
 </script>
 

--- a/styles.css
+++ b/styles.css
@@ -334,41 +334,6 @@ h2 {
   text-align: center;
 }
 
-/* About */
-.about-wrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1.5rem;
-  max-width: 1100px;
-  margin: 0 auto;
-}
-.about-wrapper img {
-  width: 100%;
-  margin: 0;
-  max-width: 320px;
-  border-radius: 8px;
-}
-.about-text {
-  text-align: center;
-}
-.about-heading {
-  font-family: "Merriweather", serif;
-  font-size: 1.5rem;
-  color: var(--vi-1);
-  margin-top: 0;
-}
-@media (min-width: 768px) {
-  .about-wrapper {
-    flex-direction: row;
-    align-items: flex-start;
-    text-align: left;
-  }
-  .about-text {
-    text-align: left;
-  }
-}
-
 .services {
   display: grid;
   gap: 2rem;
@@ -400,8 +365,8 @@ h2 {
 
 /* About */
 .about-wrapper {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr;
   align-items: center;
   gap: 2rem;
   max-width: 1100px;
@@ -412,7 +377,8 @@ h2 {
   height: auto;
   margin: 0;
   max-width: 240px;
-  border-radius: 6px;
+  border-radius: 50%;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 .about-text {
   text-align: left;
@@ -423,13 +389,69 @@ h2 {
   color: var(--vi-1);
   margin-top: 0;
 }
+.name-highlight {
+  font-weight: 700;
+}
 @media (min-width: 768px) {
   .about-wrapper {
-    flex-direction: row;
-    align-items: flex-start;
+    grid-template-columns: 240px 1fr;
   }
-  .about-text {
-    flex: 1;
+}
+
+.personal-statement .more-text {
+  display: none;
+}
+.personal-statement .more-text.open {
+  display: block;
+}
+.read-more {
+  background: none;
+  border: none;
+  color: var(--vi-1);
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+}
+.pull-quote {
+  margin: 1rem 0;
+}
+.accomplishments {
+  margin-top: 1rem;
+}
+.pattern-bg {
+  background-image: repeating-linear-gradient(45deg, var(--vi-gray) 0 10px, var(--vi-5) 10px 20px);
+}
+.fade-in {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+.fade-in.in-view {
+  opacity: 1;
+  transform: none;
+}
+.contact-columns {
+  display: grid;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+.contact-card h4 {
+  margin: 0 0 0.25rem;
+  font-family: "Merriweather", serif;
+  color: var(--vi-1);
+  font-size: 1rem;
+}
+.icon {
+  margin-right: 0.25rem;
+}
+.contact-phones,
+.contact-email {
+  margin: 0.5rem 0 0;
+}
+@media (min-width: 600px) {
+  .contact-columns {
+    grid-template-columns: repeat(3, 1fr);
   }
 }
 


### PR DESCRIPTION
## Summary
- Reworked About section with grid layout, circular profile image and optional personal statement read-more toggle.
- Added pull quote, accomplishments list, and background pattern for a more polished presentation.
- Refreshed Contact area into island-specific columns with icons and animated list items on scroll.

## Testing
- `npx --yes htmlhint about.html`
- `npx --yes stylelint styles.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_6896d01e5b3c83218d0f78e136eebecf