### PR TITLE
Remove patterned backgrounds from About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -85,7 +85,7 @@
     </div>
   </section>
 
-  <section class="bg-white pattern-bg" id="about">
+  <section class="bg-white" id="about">
     <h2 class="section-title">About Us</h2>
     <div class="about-wrapper">
       <img class="about-photo" src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/1ab4fdc6-aa8f-4845-1760-5d6bdbd1e300/public" alt="Pencil drawing of attorney Robert A. Pohl" width="1024" height="1024" />

--- a/styles.css
+++ b/styles.css
@@ -419,9 +419,6 @@ h2 {
 .accomplishments {
   margin-top: 1rem;
 }
-.pattern-bg {
-  background-image: repeating-linear-gradient(45deg, var(--vi-gray) 0 10px, var(--vi-5) 10px 20px);
-}
 .fade-in {
   opacity: 0;
   transform: translateY(20px);
@@ -463,7 +460,6 @@ h2 {
 
 .cotton-paper {
   background-color: #fdfcf9;
-  background-image: url('https://www.transparenttextures.com/patterns/paper-fibers.png');
   border: 1px solid #e5e2d6;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }


### PR DESCRIPTION
## Summary
- Drop patterned background class from the About section
- Remove textured paper image for a plain background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896d310d5a88321ad6ca4c12f97ba00