### PR TITLE
Clean up About page visuals and contact info

### DIFF
--- a/about.html
+++ b/about.html
@@ -39,9 +39,9 @@
         <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
-    <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>
+    <button id="menu-toggle" class="btn" aria-expanded="false">Menu</button>
     <nav>
-      <a href="about.html" data-icon="ℹ️">About</a>
+      <a href="about.html">About</a>
       <div class="dropdown">
         <a href="index.html#services">Services ▾</a>
         <div class="dropdown-content">
@@ -49,16 +49,16 @@
           <a href="business-bankruptcy.html">Business Bankruptcy</a>
         </div>
       </div>
-      <a href="index.html" class="mobile-only" data-icon="🏠">Home</a>
-      <a href="personal-bankruptcy.html" class="mobile-only" data-icon="👤">Personal Bankruptcy</a>
-      <a href="business-bankruptcy.html" class="mobile-only" data-icon="💼">Business Bankruptcy</a>
-      <a href="tel:+13402033333" class="mobile-only" data-icon="📞">Call Now</a>
-      <a href="#" class="mobile-only add-contact" data-icon="📇">Add Pohl Bankruptcy to My Contacts</a>
-      <a href="testimonials.html" data-icon="💬">Testimonials</a>
-      <a href="faq.html" data-icon="❓">FAQ</a>
-      <a href="contact.html" data-icon="✉️">Contact</a>
-      <a href="pay-online.html" class="btn header-pay-link" data-icon="💳">Pay Online</a>
-      <a href="#" class="mobile-only close-nav" data-icon="❌">Close</a>
+      <a href="index.html" class="mobile-only">Home</a>
+      <a href="personal-bankruptcy.html" class="mobile-only">Personal Bankruptcy</a>
+      <a href="business-bankruptcy.html" class="mobile-only">Business Bankruptcy</a>
+      <a href="tel:+13402033333" class="mobile-only">Call Now</a>
+      <a href="#" class="mobile-only add-contact">Add Pohl Bankruptcy to My Contacts</a>
+      <a href="testimonials.html">Testimonials</a>
+      <a href="faq.html">FAQ</a>
+      <a href="contact.html">Contact</a>
+      <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
+      <a href="#" class="mobile-only close-nav">Close</a>
     </nav>
   </header>
   <main id="main">
@@ -108,7 +108,7 @@
     <div class="info-section" id="contact-info">
       <h2 class="section-title">Contact</h2>
       <div class="contact-card">
-        <p><strong>U.S. Virgin Islands Offices</strong></p>
+        <h3>U.S. Virgin Islands Offices</h3>
         <details class="office-details">
           <summary>St. Thomas</summary>
           <p>5316 Yacht Haven Grande, Suite N‑104, Box 30<br />St. Thomas, VI 00802</p>
@@ -121,8 +121,11 @@
           <summary>St. Croix</summary>
           <p>6002 Diamond Ruby, Suite 3, PMB 633<br />Christiansted, VI 00820</p>
         </details>
-        <p class="contact-phones"><span class="icon" aria-hidden="true">📞</span> Office (340) 203‑3333 • Mobile (864) 361‑4827</p>
-        <p class="contact-email"><span class="icon" aria-hidden="true">✉️</span> <a href="mailto:Robert@POHLPA.com">Robert@POHLPA.com</a> <a href="#" class="download-vcard">Download vCard</a></p>
+        <div class="contact-details">
+          <p><strong>Office:</strong> (340) 203‑3333</p>
+          <p><strong>Mobile:</strong> (864) 361‑4827</p>
+          <p><strong>Email:</strong> <a href="mailto:Robert@POHLPA.com">Robert@POHLPA.com</a> <a href="#" class="download-vcard">Download vCard</a></p>
+        </div>
       </div>
     </div>
 
@@ -307,15 +310,15 @@
     <hr class="section-divider" aria-hidden="true" />
 
     <div class="info-section" id="education">
-      <h2 class="section-title"><span class="degree-icon">🎓</span> Education</h2>
+      <h2 class="section-title">Education</h2>
       <p class="education-blurb">Highlights of Robert's academic background.</p>
       <ul class="styled-list education-grid">
-        <li><span class="degree-icon">🎓</span>LL.M., Taxation <em>(Cum Laude)</em> – University of San Diego School of Law, 2000</li>
-        <li><span class="degree-icon">🎓</span>Juris Doctor – University of San Diego School of Law, 1999</li>
-        <li><span class="degree-icon">🎓</span>MBA, International Business – University of San Diego Graduate Business School, 1999</li>
-        <li><span class="degree-icon">🎓</span><em>Merit Certificate</em>, International Corporate Structure – Institute on International &amp; Comparative Law, Paris, 1996</li>
-        <li><span class="degree-icon">🎓</span>Baccalaureus Artium, English Literature – Boston College, 1991</li>
-        <li><span class="degree-icon">🎓</span><em>Merit Certificate</em>, English Literature – Harris Manchester College, Oxford University, 1990</li>
+        <li>LL.M., Taxation <em>(Cum Laude)</em> – University of San Diego School of Law, 2000</li>
+        <li>Juris Doctor – University of San Diego School of Law, 1999</li>
+        <li>MBA, International Business – University of San Diego Graduate Business School, 1999</li>
+        <li><em>Merit Certificate</em>, International Corporate Structure – Institute on International &amp; Comparative Law, Paris, 1996</li>
+        <li>Baccalaureus Artium, English Literature – Boston College, 1991</li>
+        <li><em>Merit Certificate</em>, English Literature – Harris Manchester College, Oxford University, 1990</li>
       </ul>
       <details class="courses">
         <summary>Courses &amp; Certifications</summary>
@@ -328,7 +331,7 @@
     </div>
 
     <div class="info-section" id="admissions">
-      <h2 class="section-title"><span class="icon">🏛️</span> Admissions &amp; Courts</h2>
+      <h2 class="section-title">Admissions &amp; Courts</h2>
       <ul class="styled-list admissions-list">
         <li>California (2000)</li>
         <li>District of Columbia (2002)</li>

--- a/styles.css
+++ b/styles.css
@@ -447,14 +447,10 @@ h2 {
   font-size: 1rem;
   cursor: pointer;
 }
-.icon {
-  margin-right: 0.25rem;
-}
-.contact-phones,
-.contact-email {
+.contact-details p {
   margin: 0.5rem 0 0;
 }
-.contact-email a + a {
+.contact-details a + a {
   margin-left: 0.5rem;
 }
 @media (min-width: 600px) {
@@ -831,7 +827,6 @@ a.back-to-top {display:block;margin-top:1rem;text-align:right;font-size:.875rem;
 
 .education-grid {display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;}
 .education-grid li {display:flex;align-items:flex-start;padding:.5rem;}
-.degree-icon {margin-right:.5rem;}
 .courses summary {cursor:pointer;font-weight:600;}
 
 .admissions-list {column-count:2;column-gap:1rem;}


### PR DESCRIPTION
## Summary
- Remove emoji icons from navigation, education, and admissions sections on the About page for a more professional appearance
- Redesign contact information into a text-based layout and style it with new `.contact-details` rules

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/VI_Bankruptcy_Robert/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6896db5778708321971e5fc182444759