### PR TITLE
Revamp About page sections

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,462 +1,781 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
-  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
-  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
-  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
-  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" />
-  <link rel="manifest" href="site.webmanifest" />
-  <meta name="description" content="Learn about Attorney Robert Pohl and how our firm helps Virgin Islanders find financial relief under Chapters 7, 11, 12 &amp; 13." />
-  <meta property="og:title" content="About | VI Bankruptcy" />
-  <meta property="og:description" content="Learn about Attorney Robert Pohl and how our firm helps Virgin Islanders find financial relief under Chapters 7, 11, 12 &amp; 13." />
-  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
-  <meta property="og:url" content="https://vibankruptcy.com/about.html" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
-  <link rel="canonical" href="https://vibankruptcy.com/about.html" />
-  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
-  <meta property="og:type" content="website" />
-  <meta property="og:site_name" content="VI Bankruptcy" />
-  <meta property="og:locale" content="en_US" />
-  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
-  <meta name="theme-color" content="#132326" />
-  <title>About | VI Bankruptcy</title>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="192x192"
+      href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="512x512"
+      href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public"
+    />
+    <link rel="manifest" href="site.webmanifest" />
+    <meta
+      name="description"
+      content="Learn about Attorney Robert Pohl and how our firm helps Virgin Islanders find financial relief under Chapters 7, 11, 12 &amp; 13."
+    />
+    <meta property="og:title" content="About | VI Bankruptcy" />
+    <meta
+      property="og:description"
+      content="Learn about Attorney Robert Pohl and how our firm helps Virgin Islanders find financial relief under Chapters 7, 11, 12 &amp; 13."
+    />
+    <meta
+      property="og:image"
+      content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public"
+    />
+    <meta property="og:url" content="https://vibankruptcy.com/about.html" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:image"
+      content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public"
+    />
+    <link rel="canonical" href="https://vibankruptcy.com/about.html" />
+    <meta
+      name="robots"
+      content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="VI Bankruptcy" />
+    <meta property="og:locale" content="en_US" />
+    <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+    <meta name="theme-color" content="#132326" />
+    <title>About | VI Bankruptcy</title>
 
-  <!-- Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css" />
-</head>
-<body>
-  <div id="top"></div>
-  <a class="skip-link" href="#main">Skip to content</a>
-  <header class="site-header">
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div id="top"></div>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+        <img
+          src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public"
+          alt="VI Bankruptcy icon"
+        />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
-    <button id="menu-toggle" class="btn" aria-expanded="false">Menu</button>
-    <nav>
-      <a href="about.html">About</a>
-      <div class="dropdown">
-        <a href="index.html#services">Services ▾</a>
-        <div class="dropdown-content">
-          <a href="personal-bankruptcy.html">Personal Bankruptcy</a>
-          <a href="business-bankruptcy.html">Business Bankruptcy</a>
+      <button id="menu-toggle" class="btn" aria-expanded="false">Menu</button>
+      <nav>
+        <a href="about.html">About</a>
+        <div class="dropdown">
+          <a href="index.html#services">Services ▾</a>
+          <div class="dropdown-content">
+            <a href="personal-bankruptcy.html">Personal Bankruptcy</a>
+            <a href="business-bankruptcy.html">Business Bankruptcy</a>
+          </div>
+        </div>
+        <a href="index.html" class="mobile-only">Home</a>
+        <a href="personal-bankruptcy.html" class="mobile-only"
+          >Personal Bankruptcy</a
+        >
+        <a href="business-bankruptcy.html" class="mobile-only"
+          >Business Bankruptcy</a
+        >
+        <a href="tel:+13402033333" class="mobile-only">Call Now</a>
+        <a href="#" class="mobile-only add-contact"
+          >Add Pohl Bankruptcy to My Contacts</a
+        >
+        <a href="testimonials.html">Testimonials</a>
+        <a href="faq.html">FAQ</a>
+        <a href="contact.html">Contact</a>
+        <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
+        <a href="#" class="mobile-only close-nav">Close</a>
+      </nav>
+    </header>
+    <main id="main">
+      <section class="hero hero-about">
+        <div class="hero-content">
+          <h1>About Us</h1>
+          <p class="hero-subtitle">
+            Your local bankruptcy guide in the U.S. Virgin Islands.
+          </p>
+          <p>
+            Robert Pohl has helped residents regain financial freedom for over
+            25 years.
+          </p>
+          <div class="hero-actions desktop-only">
+            <a href="#about" class="btn">Meet Robert</a>
+            <a href="contact.html" class="btn btn-secondary">Contact</a>
+          </div>
+          <div class="hero-links desktop-only">
+            <a href="#about">About</a>
+            <a href="#experience">Experience</a>
+            <a href="#education">Education</a>
+            <a href="#admissions">Admissions</a>
+            <a href="#licenses">Licenses</a>
+            <a href="#approach">Approach</a>
+            <a href="#contact-info">Contact</a>
+          </div>
+        </div>
+      </section>
+
+      <div class="mobile-hero-links">
+        <div class="hero-actions">
+          <a href="#about" class="btn">Meet Robert</a>
+          <a href="contact.html" class="btn btn-secondary">Contact</a>
+        </div>
+        <div class="hero-links">
+          <a href="#about">About</a>
+          <a href="#experience">Experience</a>
+          <a href="#education">Education</a>
+          <a href="#admissions">Admissions</a>
+          <a href="#licenses">Licenses</a>
+          <a href="#approach">Approach</a>
+          <a href="#contact-info">Contact</a>
         </div>
       </div>
-      <a href="index.html" class="mobile-only">Home</a>
-      <a href="personal-bankruptcy.html" class="mobile-only">Personal Bankruptcy</a>
-      <a href="business-bankruptcy.html" class="mobile-only">Business Bankruptcy</a>
-      <a href="tel:+13402033333" class="mobile-only">Call Now</a>
-      <a href="#" class="mobile-only add-contact">Add Pohl Bankruptcy to My Contacts</a>
-      <a href="testimonials.html">Testimonials</a>
-      <a href="faq.html">FAQ</a>
-      <a href="contact.html">Contact</a>
-      <a href="pay-online.html" class="btn header-pay-link">Pay Online</a>
-      <a href="#" class="mobile-only close-nav">Close</a>
-    </nav>
-  </header>
-  <main id="main">
 
-  <section class="hero hero-about">
-    <div class="hero-content">
-      <h1>About Us</h1>
-      <p class="hero-subtitle">Your local bankruptcy guide in the U.S. Virgin Islands.</p>
-      <p>Robert Pohl has helped residents regain financial freedom for over 25 years.</p>
-      <div class="hero-actions">
-        <a href="#about" class="btn">Meet Robert</a>
-        <a href="contact.html" class="btn btn-secondary">Contact</a>
-      </div>
-      <div class="hero-links">
-        <a href="#about">About</a>
-        <a href="#experience">Experience</a>
-        <a href="#education">Education</a>
-        <a href="#admissions">Admissions</a>
-        <a href="#licenses">Licenses</a>
-        <a href="#approach">Approach</a>
-        <a href="#contact-info">Contact</a>
-      </div>
-    </div>
-  </section>
-
-  <section class="bg-white" id="about">
-    <h2 class="section-title">Meet Attorney Pohl</h2>
-    <div class="about-wrapper">
-      <img class="about-photo" src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/1ab4fdc6-aa8f-4845-1760-5d6bdbd1e300/public" alt="Pencil drawing of attorney Robert A. Pohl" width="1024" height="1024" />
-      <div class="about-text">
-        <h3 class="about-heading"><span class="name-highlight">Robert A. Pohl</span> – Bankruptcy Attorney</h3>
-        <div class="personal-statement">
-          <p>Robert A. Pohl is a seasoned bankruptcy attorney holding a J.D., LL.M. in Tax, and an MBA. Admitted in the U.S. Virgin Islands and multiple states, he has spent more than 25&nbsp;years helping individuals and businesses overcome debt.</p>
-          <p class="more-text">Each client is unique, and each situation is unique. <q>The difference between good and amazing service is not only addressing the common problems but tailoring solutions to attend to each detail that is unique.</q> I believe in taking the time to get to know each client and making sure that they are well taken care of.</p>
-          <button class="read-more" aria-expanded="false">Read more</button>
+      <section class="bg-white" id="about">
+        <h2 class="section-title section-title-left">Meet Attorney Pohl</h2>
+        <div class="about-wrapper">
+          <img
+            class="about-photo"
+            src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/1ab4fdc6-aa8f-4845-1760-5d6bdbd1e300/public"
+            alt="Pencil drawing of attorney Robert A. Pohl"
+            width="1024"
+            height="1024"
+          />
+          <div class="about-text">
+            <h3 class="about-heading">
+              <span class="name-highlight">Robert A. Pohl</span> – Bankruptcy
+              Attorney
+            </h3>
+            <div class="personal-statement">
+              <p>
+                Robert A. Pohl is a seasoned bankruptcy attorney holding a J.D.,
+                LL.M. in Tax, and an MBA. Admitted in the U.S. Virgin Islands
+                and multiple states, he has spent more than 25&nbsp;years
+                helping individuals and businesses overcome debt.
+              </p>
+              <p class="more-text">
+                Each client is unique, and each situation is unique.
+                <q
+                  >The difference between good and amazing service is not only
+                  addressing the common problems but tailoring solutions to
+                  attend to each detail that is unique.</q
+                >
+                I believe in taking the time to get to know each client and
+                making sure that they are well taken care of.
+              </p>
+              <button class="read-more" aria-expanded="false">Read more</button>
+            </div>
+            <blockquote class="pull-quote">
+              Financial freedom starts with honest advice and tailored strategy.
+            </blockquote>
+            <ul class="styled-list accomplishments">
+              <li>25+ years guiding clients through bankruptcy</li>
+              <li>Admitted in the U.S. Virgin Islands and multiple states</li>
+              <li>Advanced degrees in Law, Taxation and Business</li>
+            </ul>
+          </div>
         </div>
-        <blockquote class="pull-quote">Financial freedom starts with honest advice and tailored strategy.</blockquote>
-        <ul class="styled-list accomplishments">
-          <li>25+ years guiding clients through bankruptcy</li>
-          <li>Admitted in the U.S. Virgin Islands and multiple states</li>
-          <li>Advanced degrees in Law, Taxation and Business</li>
-        </ul>
-      </div>
-    </div>
-  </section>
-  <section class="bg-white">
-    <div class="info-section" id="contact-info">
-      <h2 class="section-title">Contact</h2>
-      <div class="contact-card">
-        <h3>U.S. Virgin Islands Offices</h3>
-        <details class="office-details">
-          <summary>St. Thomas</summary>
-          <p>5316 Yacht Haven Grande, Suite N‑104, Box 30<br />St. Thomas, VI 00802</p>
-        </details>
-        <details class="office-details">
-          <summary>St. John</summary>
-          <p>5000 Estate Enighed, P.O. Box 343<br />St. John, VI 00830</p>
-        </details>
-        <details class="office-details">
-          <summary>St. Croix</summary>
-          <p>6002 Diamond Ruby, Suite 3, PMB 633<br />Christiansted, VI 00820</p>
-        </details>
-        <div class="contact-details">
-          <p><strong>Office:</strong> (340) 203‑3333</p>
-          <p><strong>Mobile:</strong> (864) 361‑4827</p>
-          <p><strong>Email:</strong> <a href="mailto:Robert@POHLPA.com">Robert@POHLPA.com</a> <a href="#" class="download-vcard">Download vCard</a></p>
+      </section>
+      <section class="bg-white">
+        <div class="info-section contact-section" id="contact-info">
+          <h2 class="section-title section-title-left">Contact</h2>
+          <h3 class="contact-subtitle">
+            Proudly Serving Clients Located in the Virgin Islands
+          </h3>
+          <div class="contact-card">
+            <h3>U.S. Virgin Islands Offices</h3>
+            <details class="office-details">
+              <summary>St. Thomas</summary>
+              <p>
+                5316 Yacht Haven Grande, Suite N‑104, Box 30<br />St. Thomas, VI
+                00802
+              </p>
+            </details>
+            <details class="office-details">
+              <summary>St. John</summary>
+              <p>5000 Estate Enighed, P.O. Box 343<br />St. John, VI 00830</p>
+            </details>
+            <details class="office-details">
+              <summary>St. Croix</summary>
+              <p>
+                6002 Diamond Ruby, Suite 3, PMB 633<br />Christiansted, VI 00820
+              </p>
+            </details>
+            <div class="contact-details">
+              <p><strong>Office:</strong> (340) 203‑3333</p>
+              <p><strong>Mobile:</strong> (864) 361‑4827</p>
+              <p>
+                <strong>Email:</strong>
+                <a href="mailto:Robert@POHLPA.com">Robert@POHLPA.com</a>
+                <a href="#" class="download-vcard">Download vCard</a>
+              </p>
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
 
-    <div class="info-section" id="summary">
-      <h2 class="section-title">Professional Summary</h2>
-      <div class="summary-content">
-        <div class="summary-main">
-          <h3>Overview</h3>
-          <p>Bankruptcy and financial‑litigation attorney practicing since 2000, serving individuals and businesses across the U.S. Virgin Islands through offices on St. Thomas, St. John, and St. Croix.</p>
-          <h3>Practice Focus</h3>
-          <p>Founder of POHL, P.A. and POHL Bankruptcy, LLC with a practice centered on debtor representation and strategic financial guidance.</p>
-          <details class="accordion">
-            <summary>Additional Expertise</summary>
-            <p>Experience includes distressed debt, bankruptcy filings and litigation, tax litigation and planning, corporate and securities work, real estate, estate planning, and related matters.</p>
+        <div class="info-section bg-white" id="summary">
+          <h2 class="section-title section-title-left">Professional Summary</h2>
+          <div class="summary-content">
+            <div class="summary-main">
+              <h3 class="about-heading">Overview</h3>
+              <div class="personal-statement">
+                <p>
+                  Bankruptcy and financial‑litigation attorney practicing since
+                  2000, serving individuals and businesses across the U.S.
+                  Virgin Islands through offices on St. Thomas, St. John, and
+                  St. Croix.
+                </p>
+              </div>
+              <h3>Practice Focus</h3>
+              <p>
+                Founder of POHL, P.A. and POHL Bankruptcy, LLC with a practice
+                centered on debtor representation and strategic financial
+                guidance.
+              </p>
+              <details class="accordion" open>
+                <summary>Additional Expertise</summary>
+                <p>
+                  Experience includes distressed debt, bankruptcy filings and
+                  litigation, tax litigation and planning, corporate and
+                  securities work, real estate, estate planning, and related
+                  matters.
+                </p>
+              </details>
+              <a href="contact.html" class="btn request-consult"
+                >Request Consultation</a
+              >
+            </div>
+            <aside class="summary-sidebar">
+              <h3>Core Expertise</h3>
+              <ul class="styled-list">
+                <li><strong>Bankruptcy filings</strong></li>
+                <li><strong>Financial litigation</strong></li>
+                <li><em>Tax planning &amp; litigation</em></li>
+                <li>Corporate &amp; securities law</li>
+              </ul>
+            </aside>
+          </div>
+        </div>
+
+        <section class="bg-gray experience-wrapper" id="experience">
+          <h2 class="section-title section-title-left">Legal Experience</h2>
+          <hr class="section-divider full-width" aria-hidden="true" />
+          <div class="info-section cotton-paper">
+            <div class="timeline">
+              <details class="timeline-item" open>
+                <summary>
+                  <span class="company">POHL, P.A.</span> – President
+                  <span class="dates">2012–Present</span>
+                </summary>
+                <p>
+                  Established a boutique law firm specializing in financial
+                  litigation including distressed debt purchases, hard money
+                  lending, bankruptcy, tax litigation and planning, estate
+                  planning, securities offerings and corporate services for
+                  small to mid‑sized clients.
+                </p>
+                <p>
+                  Developed a fully integrated and paperless practice managing
+                  749 clients and generating over $1MM in annual fees as a sole
+                  practitioner using automated systems and customized software.
+                </p>
+                <ul class="styled-list skills">
+                  <li>Financial litigation</li>
+                  <li>Practice automation</li>
+                </ul>
+              </details>
+
+              <details class="timeline-item" open>
+                <summary>
+                  <span class="company">POHL Bankruptcy, LLC</span> – Manager
+                  <span class="dates">2021–Present</span>
+                </summary>
+                <p>
+                  Established a bankruptcy firm focused on representing debtors
+                  in filings, litigation and related matters.
+                </p>
+                <ul class="styled-list skills">
+                  <li>Debtor advocacy</li>
+                  <li>Bankruptcy litigation</li>
+                </ul>
+              </details>
+
+              <details class="timeline-item" open>
+                <summary>
+                  <span class="company"
+                    >POHL Capital, LLC (dba POHL Realty)</span
+                  >
+                  – Manager <span class="dates">201?–Present</span>
+                </summary>
+                <p>
+                  Founded a real estate brokerage specializing in listing,
+                  marketing and selling distressed residential and commercial
+                  property.
+                </p>
+                <ul class="styled-list skills">
+                  <li>Distressed property sales</li>
+                  <li>Brokerage management</li>
+                </ul>
+              </details>
+
+              <details class="timeline-item" open>
+                <summary>
+                  <span class="company">POHL Title Company, LLC</span> – Manager
+                  &amp; Sole Member <span class="dates">2012–Present</span>
+                </summary>
+                <p>
+                  Manage a title insurance agency licensed with First American
+                  Title Insurance Company within South Carolina.
+                </p>
+                <ul class="styled-list skills">
+                  <li>Title insurance</li>
+                  <li>Agency management</li>
+                </ul>
+              </details>
+
+              <details class="timeline-item" open>
+                <summary>
+                  <span class="company">POHL Talent Management, LLC</span> –
+                  Manager <span class="dates">2018–Present</span>
+                </summary>
+                <p>
+                  Established a talent agency representing musicians, writers,
+                  actors, athletes and other performers.
+                </p>
+                <ul class="styled-list skills">
+                  <li>Talent representation</li>
+                  <li>Contract negotiation</li>
+                </ul>
+              </details>
+
+              <details class="timeline-item" open>
+                <summary>
+                  <span class="company">POHL Property Management, LLC</span> –
+                  Manager &amp; Sole Member <span class="dates">2012–2013</span>
+                </summary>
+                <p>
+                  Managed and sold a property management business overseeing
+                  residential and commercial properties including investment
+                  homes, a bar, a restaurant and a hotel.
+                </p>
+                <ul class="styled-list skills">
+                  <li>Property management</li>
+                  <li>Asset disposition</li>
+                </ul>
+              </details>
+
+              <details class="timeline-item" open>
+                <summary>
+                  <span class="company">Stodghill Law Firm Chartered</span> –
+                  Associate <span class="dates">2011–2012</span>
+                </summary>
+                <p>
+                  Performed duties similar to a corporate bankruptcy associate,
+                  supporting complex restructuring matters.
+                </p>
+                <ul class="styled-list skills">
+                  <li>Corporate bankruptcy</li>
+                  <li>Client counseling</li>
+                </ul>
+              </details>
+
+              <details class="timeline-item" open>
+                <summary>
+                  <span class="company">The Cooper Law Firm</span> – Corporate
+                  Bankruptcy Associate <span class="dates">2010–2011</span>
+                </summary>
+                <p>
+                  Interviewed, negotiated and managed individuals and businesses
+                  in restructuring debt and monetizing assets through financing,
+                  liability restructuring and bankruptcy filings.
+                </p>
+                <p>
+                  Drafted and argued adversarial proceedings, motions,
+                  applications and plans before the U.S. Bankruptcy Court.
+                </p>
+                <ul class="styled-list skills">
+                  <li>Adversarial litigation</li>
+                  <li>Restructuring strategy</li>
+                </ul>
+              </details>
+
+              <details class="timeline-item" open>
+                <summary>
+                  <span class="company">Resurgent Capital Services, LP</span> –
+                  Manager, Legal Services Compliance
+                  <span class="dates">2009–2010</span>
+                </summary>
+                <p>
+                  Analyzed distressed asset portfolios ranging from $2MM–$500MM
+                  and developed litigation and liquidation plans to maximize
+                  recovery.
+                </p>
+                <p>
+                  Managed bankruptcy litigation, foreclosure and international
+                  mortgage servicing departments overseeing secured accounts
+                  across North America and the Caribbean.
+                </p>
+                <ul class="styled-list skills">
+                  <li>Distressed asset recovery</li>
+                  <li>Portfolio management</li>
+                </ul>
+              </details>
+
+              <details class="timeline-item" open>
+                <summary>
+                  <span class="company"
+                    >Fell, Marking, Abkin, Montgomery, Granet &amp; Raney,
+                    LLP</span
+                  >
+                  – Associate <span class="dates">2008–2009</span>
+                </summary>
+                <p>
+                  Produced formation documents, licensing applications and
+                  related materials to establish and finance businesses.
+                </p>
+                <p>
+                  Drafted legal memos, briefs, opinions and research related to
+                  taxes, liability, insurance, real property and land use.
+                </p>
+                <ul class="styled-list skills">
+                  <li>Business formation</li>
+                  <li>Legal research</li>
+                </ul>
+              </details>
+
+              <details class="timeline-item" open>
+                <summary>
+                  <span class="company">Quality Loans, LLC</span> – General
+                  Counsel, Executive Managing Director
+                  <span class="dates">2007–2008</span>
+                </summary>
+                <p>
+                  Formed a Delaware LLC to acquire, sell, securitize and trade
+                  mortgage loans and similar instruments.
+                </p>
+                <p>
+                  Negotiated leases and agreements, arranged capital and oversaw
+                  licensing to originate, sell and securitize financial
+                  instruments.
+                </p>
+                <ul class="styled-list skills">
+                  <li>Securitization</li>
+                  <li>Capital raising</li>
+                </ul>
+              </details>
+
+              <details class="timeline-item" open>
+                <summary>
+                  <span class="company">Quality Home Loans</span> – General
+                  Counsel, Executive Managing Director
+                  <span class="dates">2006–2007</span>
+                </summary>
+                <p>
+                  Managed legal, correspondent and capital‑markets divisions
+                  completing ~$1B in mortgage originations and securities
+                  annually.
+                </p>
+                <p>
+                  Raised $60MM in private equity and $50MM in commercial paper
+                  while establishing $300MM in credit facilities.
+                </p>
+                <ul class="styled-list skills">
+                  <li>Mortgage finance</li>
+                  <li>Compliance management</li>
+                </ul>
+              </details>
+
+              <details class="timeline-item" open>
+                <summary>
+                  <span class="company">Countrywide Home Loans, Inc.</span> –
+                  First Vice President, Senior Legal Counsel
+                  <span class="dates">2002–2006</span>
+                </summary>
+                <p>
+                  Managed teams purchasing, selling and securitizing
+                  approximately $9B per month of mortgage loans.
+                </p>
+                <p>
+                  Drafted and negotiated agreements, advised on underwriting and
+                  servicing issues and developed compliance procedures.
+                </p>
+                <ul class="styled-list skills">
+                  <li>Mortgage securitization</li>
+                  <li>Regulatory compliance</li>
+                </ul>
+              </details>
+
+              <details class="timeline-item" open>
+                <summary>
+                  <span class="company"
+                    >California Association of REALTORS&reg;, Inc.</span
+                  >
+                  – Corporate Attorney <span class="dates">2001–2002</span>
+                </summary>
+                <p>
+                  Prepared formation documents, acquired venture capital and
+                  advised officers and directors across nine entities.
+                </p>
+                <p>
+                  Handled acquisitions, IP matters, contract negotiations and
+                  compliance for campaign and political laws.
+                </p>
+                <ul class="styled-list skills">
+                  <li>Corporate governance</li>
+                  <li>Intellectual property</li>
+                </ul>
+              </details>
+
+              <details class="timeline-item" open>
+                <summary>
+                  <span class="company">KPMG, LLP</span> – Senior Tax Specialist
+                  <span class="dates">2000–2001</span>
+                </summary>
+                <p>
+                  Interpreted state tax and corporate codes to devise plans
+                  decreasing taxes by over 80%.
+                </p>
+                <p>
+                  Implemented tax‑minimization strategies and secured a $20MM
+                  refund through incentives and credit programs.
+                </p>
+                <ul class="styled-list skills">
+                  <li>Tax planning</li>
+                  <li>Incentive negotiation</li>
+                </ul>
+              </details>
+            </div>
+            <a href="#top" class="back-to-top">Back to top</a>
+          </div>
+        </section>
+
+        <hr class="section-divider" aria-hidden="true" />
+
+        <div class="info-section bg-white" id="education">
+          <h2 class="section-title section-title-left">Education</h2>
+          <p class="education-blurb">
+            Highlights of Robert's academic background.
+          </p>
+          <ul class="styled-list education-grid">
+            <li>
+              LL.M., Taxation <em>(Cum Laude)</em> – University of San Diego
+              School of Law, 2000
+            </li>
+            <li>Juris Doctor – University of San Diego School of Law, 1999</li>
+            <li>
+              MBA, International Business – University of San Diego Graduate
+              Business School, 1999
+            </li>
+            <li>
+              <em>Merit Certificate</em>, International Corporate Structure –
+              Institute on International &amp; Comparative Law, Paris, 1996
+            </li>
+            <li>
+              Baccalaureus Artium, English Literature – Boston College, 1991
+            </li>
+            <li>
+              <em>Merit Certificate</em>, English Literature – Harris Manchester
+              College, Oxford University, 1990
+            </li>
+          </ul>
+          <details class="courses" open>
+            <summary>Courses &amp; Certifications</summary>
+            <ul class="styled-list">
+              <li>Bankruptcy Law Workshop – ABA, 2023</li>
+              <li>Certified Mediator Training – 2021</li>
+            </ul>
           </details>
-          <a href="contact.html" class="btn request-consult">Request Consultation</a>
+          <a href="cv.pdf" class="btn" download>Download CV</a>
         </div>
-        <aside class="summary-sidebar">
-          <h3>Core Expertise</h3>
-          <ul class="styled-list">
-            <li><strong>Bankruptcy filings</strong></li>
-            <li><strong>Financial litigation</strong></li>
-            <li><em>Tax planning &amp; litigation</em></li>
-            <li>Corporate &amp; securities law</li>
-          </ul>
-        </aside>
-      </div>
-    </div>
+        <div class="info-section bg-dark-gray" id="admissions">
+          <h2 class="section-title section-title-left">
+            Admissions &amp; Courts
+          </h2>
+          <div class="admissions-grid">
+            <div>
+              <h3>Admissions</h3>
+              <ul class="styled-list admissions-list">
+                <li>California (2000)</li>
+                <li>District of Columbia (2002)</li>
+                <li>Tennessee (2008)</li>
+                <li>North Carolina (2009)</li>
+                <li>South Carolina (2010)</li>
+              </ul>
+            </div>
+            <div>
+              <h3>Courts</h3>
+              <ul class="styled-list admissions-list">
+                <li>United States Federal Courts (2000)</li>
+                <li>United States Tax Court (2000)</li>
+                <li>United States Supreme Court (2006)</li>
+                <li>United States Bankruptcy Court (2010)</li>
+              </ul>
+            </div>
+          </div>
+        </div>
 
-    <hr class="section-divider" aria-hidden="true" />
+        <div class="info-section" id="licenses">
+          <h2 class="section-title section-title-left">Additional Licenses</h2>
+          <div class="license-list">
+            <h3 class="license-type">Insurance</h3>
+            <ul class="styled-list">
+              <li>
+                Insurance Broker: South Carolina (2013)
+                <a href="https://doi.sc.gov" target="_blank" rel="noopener"
+                  >Learn more</a
+                >
+              </li>
+            </ul>
+            <h3 class="license-type">Real Estate</h3>
+            <ul class="styled-list">
+              <li>
+                Real Estate Broker: South Carolina (2012)
+                <a href="https://llr.sc.gov" target="_blank" rel="noopener"
+                  >Learn more</a
+                >
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
 
-    <div class="info-section cotton-paper" id="experience">
-      <h2 class="section-title">Legal Experience</h2>
-      <div class="timeline">
-        <details class="timeline-item">
-          <summary><span class="company">POHL, P.A.</span> – President <span class="dates">2012–Present</span></summary>
-          <p>Established a boutique law firm specializing in financial litigation including distressed debt purchases, hard money lending, bankruptcy, tax litigation and planning, estate planning, securities offerings and corporate services for small to mid‑sized clients.</p>
-          <p>Developed a fully integrated and paperless practice managing 749 clients and generating over $1MM in annual fees as a sole practitioner using automated systems and customized software.</p>
-          <ul class="styled-list skills">
-            <li>Financial litigation</li>
-            <li>Practice automation</li>
-          </ul>
-        </details>
-
-        <details class="timeline-item">
-          <summary><span class="company">POHL Bankruptcy, LLC</span> – Manager <span class="dates">2021–Present</span></summary>
-          <p>Established a bankruptcy firm focused on representing debtors in filings, litigation and related matters.</p>
-          <ul class="styled-list skills">
-            <li>Debtor advocacy</li>
-            <li>Bankruptcy litigation</li>
-          </ul>
-        </details>
-
-        <details class="timeline-item">
-          <summary><span class="company">POHL Capital, LLC (dba POHL Realty)</span> – Manager <span class="dates">201?–Present</span></summary>
-          <p>Founded a real estate brokerage specializing in listing, marketing and selling distressed residential and commercial property.</p>
-          <ul class="styled-list skills">
-            <li>Distressed property sales</li>
-            <li>Brokerage management</li>
-          </ul>
-        </details>
-
-        <details class="timeline-item">
-          <summary><span class="company">POHL Title Company, LLC</span> – Manager &amp; Sole Member <span class="dates">2012–Present</span></summary>
-          <p>Manage a title insurance agency licensed with First American Title Insurance Company within South Carolina.</p>
-          <ul class="styled-list skills">
-            <li>Title insurance</li>
-            <li>Agency management</li>
-          </ul>
-        </details>
-
-        <details class="timeline-item">
-          <summary><span class="company">POHL Talent Management, LLC</span> – Manager <span class="dates">2018–Present</span></summary>
-          <p>Established a talent agency representing musicians, writers, actors, athletes and other performers.</p>
-          <ul class="styled-list skills">
-            <li>Talent representation</li>
-            <li>Contract negotiation</li>
-          </ul>
-        </details>
-
-        <details class="timeline-item">
-          <summary><span class="company">POHL Property Management, LLC</span> – Manager &amp; Sole Member <span class="dates">2012–2013</span></summary>
-          <p>Managed and sold a property management business overseeing residential and commercial properties including investment homes, a bar, a restaurant and a hotel.</p>
-          <ul class="styled-list skills">
-            <li>Property management</li>
-            <li>Asset disposition</li>
-          </ul>
-        </details>
-
-        <details class="timeline-item">
-          <summary><span class="company">Stodghill Law Firm Chartered</span> – Associate <span class="dates">2011–2012</span></summary>
-          <p>Performed duties similar to a corporate bankruptcy associate, supporting complex restructuring matters.</p>
-          <ul class="styled-list skills">
-            <li>Corporate bankruptcy</li>
-            <li>Client counseling</li>
-          </ul>
-        </details>
-
-        <details class="timeline-item">
-          <summary><span class="company">The Cooper Law Firm</span> – Corporate Bankruptcy Associate <span class="dates">2010–2011</span></summary>
-          <p>Interviewed, negotiated and managed individuals and businesses in restructuring debt and monetizing assets through financing, liability restructuring and bankruptcy filings.</p>
-          <p>Drafted and argued adversarial proceedings, motions, applications and plans before the U.S. Bankruptcy Court.</p>
-          <ul class="styled-list skills">
-            <li>Adversarial litigation</li>
-            <li>Restructuring strategy</li>
-          </ul>
-        </details>
-
-        <details class="timeline-item">
-          <summary><span class="company">Resurgent Capital Services, LP</span> – Manager, Legal Services Compliance <span class="dates">2009–2010</span></summary>
-          <p>Analyzed distressed asset portfolios ranging from $2MM–$500MM and developed litigation and liquidation plans to maximize recovery.</p>
-          <p>Managed bankruptcy litigation, foreclosure and international mortgage servicing departments overseeing secured accounts across North America and the Caribbean.</p>
-          <ul class="styled-list skills">
-            <li>Distressed asset recovery</li>
-            <li>Portfolio management</li>
-          </ul>
-        </details>
-
-        <details class="timeline-item">
-          <summary><span class="company">Fell, Marking, Abkin, Montgomery, Granet &amp; Raney, LLP</span> – Associate <span class="dates">2008–2009</span></summary>
-          <p>Produced formation documents, licensing applications and related materials to establish and finance businesses.</p>
-          <p>Drafted legal memos, briefs, opinions and research related to taxes, liability, insurance, real property and land use.</p>
-          <ul class="styled-list skills">
-            <li>Business formation</li>
-            <li>Legal research</li>
-          </ul>
-        </details>
-
-        <details class="timeline-item">
-          <summary><span class="company">Quality Loans, LLC</span> – General Counsel, Executive Managing Director <span class="dates">2007–2008</span></summary>
-          <p>Formed a Delaware LLC to acquire, sell, securitize and trade mortgage loans and similar instruments.</p>
-          <p>Negotiated leases and agreements, arranged capital and oversaw licensing to originate, sell and securitize financial instruments.</p>
-          <ul class="styled-list skills">
-            <li>Securitization</li>
-            <li>Capital raising</li>
-          </ul>
-        </details>
-
-        <details class="timeline-item">
-          <summary><span class="company">Quality Home Loans</span> – General Counsel, Executive Managing Director <span class="dates">2006–2007</span></summary>
-          <p>Managed legal, correspondent and capital‑markets divisions completing ~$1B in mortgage originations and securities annually.</p>
-          <p>Raised $60MM in private equity and $50MM in commercial paper while establishing $300MM in credit facilities.</p>
-          <ul class="styled-list skills">
-            <li>Mortgage finance</li>
-            <li>Compliance management</li>
-          </ul>
-        </details>
-
-        <details class="timeline-item">
-          <summary><span class="company">Countrywide Home Loans, Inc.</span> – First Vice President, Senior Legal Counsel <span class="dates">2002–2006</span></summary>
-          <p>Managed teams purchasing, selling and securitizing approximately $9B per month of mortgage loans.</p>
-          <p>Drafted and negotiated agreements, advised on underwriting and servicing issues and developed compliance procedures.</p>
-          <ul class="styled-list skills">
-            <li>Mortgage securitization</li>
-            <li>Regulatory compliance</li>
-          </ul>
-        </details>
-
-        <details class="timeline-item">
-          <summary><span class="company">California Association of REALTORS&reg;, Inc.</span> – Corporate Attorney <span class="dates">2001–2002</span></summary>
-          <p>Prepared formation documents, acquired venture capital and advised officers and directors across nine entities.</p>
-          <p>Handled acquisitions, IP matters, contract negotiations and compliance for campaign and political laws.</p>
-          <ul class="styled-list skills">
-            <li>Corporate governance</li>
-            <li>Intellectual property</li>
-          </ul>
-        </details>
-
-        <details class="timeline-item">
-          <summary><span class="company">KPMG, LLP</span> – Senior Tax Specialist <span class="dates">2000–2001</span></summary>
-          <p>Interpreted state tax and corporate codes to devise plans decreasing taxes by over 80%.</p>
-          <p>Implemented tax‑minimization strategies and secured a $20MM refund through incentives and credit programs.</p>
-          <ul class="styled-list skills">
-            <li>Tax planning</li>
-            <li>Incentive negotiation</li>
-          </ul>
-        </details>
-      </div>
-      <a href="#top" class="back-to-top">Back to top</a>
-    </div>
-
-    <hr class="section-divider" aria-hidden="true" />
-
-    <div class="info-section" id="education">
-      <h2 class="section-title">Education</h2>
-      <p class="education-blurb">Highlights of Robert's academic background.</p>
-      <ul class="styled-list education-grid">
-        <li>LL.M., Taxation <em>(Cum Laude)</em> – University of San Diego School of Law, 2000</li>
-        <li>Juris Doctor – University of San Diego School of Law, 1999</li>
-        <li>MBA, International Business – University of San Diego Graduate Business School, 1999</li>
-        <li><em>Merit Certificate</em>, International Corporate Structure – Institute on International &amp; Comparative Law, Paris, 1996</li>
-        <li>Baccalaureus Artium, English Literature – Boston College, 1991</li>
-        <li><em>Merit Certificate</em>, English Literature – Harris Manchester College, Oxford University, 1990</li>
-      </ul>
-      <details class="courses">
-        <summary>Courses &amp; Certifications</summary>
-        <ul class="styled-list">
-          <li>Bankruptcy Law Workshop – ABA, 2023</li>
-          <li>Certified Mediator Training – 2021</li>
+      <section class="bg-gray" id="approach">
+        <h2 class="section-title">The Pohl Approach</h2>
+        <ul class="why-list styled-list">
+          <li>
+            <strong>Personalized Attention</strong> – each case receives
+            tailored strategies.
+          </li>
+          <li>
+            <strong>Straightforward Advice</strong> – clear guidance without
+            legal jargon.
+          </li>
+          <li>
+            <strong>Confidential &amp; Compassionate</strong> – your situation
+            is handled with care.
+          </li>
         </ul>
-      </details>
-      <a href="cv.pdf" class="btn" download>Download CV</a>
-    </div>
+      </section>
 
-    <div class="info-section" id="admissions">
-      <h2 class="section-title">Admissions &amp; Courts</h2>
-      <ul class="styled-list admissions-list">
-        <li>California (2000)</li>
-        <li>District of Columbia (2002)</li>
-        <li>Tennessee (2008)</li>
-        <li>North Carolina (2009)</li>
-        <li>South Carolina (2010)</li>
-        <li>United States Federal Courts (2000)</li>
-        <li>United States Tax Court (2000)</li>
-        <li>United States Supreme Court (2006)</li>
-        <li>United States Bankruptcy Court (2010)</li>
-      </ul>
-    </div>
+      <section class="cta bg-white">
+        <p>
+          Need advice on your situation? We're here to help –
+          <strong>get your free consultation</strong>.
+        </p>
+        <a href="contact.html" class="btn">Contact Us</a>
+      </section>
+    </main>
 
-    <div class="info-section" id="licenses">
-      <h2 class="section-title">Additional Licenses</h2>
-      <div class="license-list">
-        <h3 class="license-type">Insurance</h3>
-        <ul class="styled-list">
-          <li>Insurance Broker: South Carolina (2013) <a href="https://doi.sc.gov" target="_blank" rel="noopener">Learn more</a></li>
-        </ul>
-        <h3 class="license-type">Real Estate</h3>
-        <ul class="styled-list">
-          <li>Real Estate Broker: South Carolina (2012) <a href="https://llr.sc.gov" target="_blank" rel="noopener">Learn more</a></li>
-        </ul>
-      </div>
-    </div>
-  </section>
+    <footer>
+      &copy; 2025 viBankruptcy.com · POHL BANKRUPTCY, LLC ·
+      <a href="pay-online.html">Pay Online</a> ·
+      <a href="privacy-policy.html">Privacy Policy</a> ·
+      <a href="disclaimer.html">Disclaimer</a>
+    </footer>
 
-  <section class="bg-gray" id="approach">
-    <h2 class="section-title">The Pohl Approach</h2>
-    <ul class="why-list styled-list">
-      <li><strong>Personalized Attention</strong> – each case receives tailored strategies.</li>
-      <li><strong>Straightforward Advice</strong> – clear guidance without legal jargon.</li>
-      <li><strong>Confidential &amp; Compassionate</strong> – your situation is handled with care.</li>
-    </ul>
-  </section>
+    <a href="#top" id="back-to-top">↑ Top</a>
 
-  <section class="cta bg-white">
-    <p>Need advice on your situation? We're here to help – <strong>get your free consultation</strong>.</p>
-      <a href="contact.html" class="btn">Contact Us</a>
-  </section>
-
-  </main>
-
-  <footer>
-    &copy; 2025 viBankruptcy.com · POHL BANKRUPTCY, LLC · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
-  </footer>
-
-  <a href="#top" id="back-to-top">↑ Top</a>
-
-<script>
-  const menuToggle = document.getElementById('menu-toggle');
-  const nav = document.querySelector('header nav');
-  menuToggle.addEventListener('click', () => {
-    const open = nav.classList.toggle('open');
-    menuToggle.setAttribute('aria-expanded', open);
-  });
-  const triggerVCard = (e) => {
-    e.preventDefault();
-    const vCard = `BEGIN:VCARD\nVERSION:3.0\nFN:Pohl Bankruptcy\nORG:Pohl Bankruptcy, LLC\nTEL;TYPE=work,voice:+1-340-203-3333\nEMAIL:robert@pohlbankruptcy.com\nEND:VCARD`;
-    const blob = new Blob([vCard], { type: 'text/vcard' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'pohl-bankruptcy.vcf';
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-  };
-
-  nav.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', (e) => {
-      if (link.classList.contains('add-contact')) {
-        triggerVCard(e);
-      }
-      if (link.classList.contains('close-nav')) {
+    <script>
+      const menuToggle = document.getElementById("menu-toggle");
+      const nav = document.querySelector("header nav");
+      menuToggle.addEventListener("click", () => {
+        const open = nav.classList.toggle("open");
+        menuToggle.setAttribute("aria-expanded", open);
+      });
+      const triggerVCard = (e) => {
         e.preventDefault();
+        const vCard = `BEGIN:VCARD\nVERSION:3.0\nFN:Pohl Bankruptcy\nORG:Pohl Bankruptcy, LLC\nTEL;TYPE=work,voice:+1-340-203-3333\nEMAIL:robert@pohlbankruptcy.com\nEND:VCARD`;
+        const blob = new Blob([vCard], { type: "text/vcard" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "pohl-bankruptcy.vcf";
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      };
+
+      nav.querySelectorAll("a").forEach((link) => {
+        link.addEventListener("click", (e) => {
+          if (link.classList.contains("add-contact")) {
+            triggerVCard(e);
+          }
+          if (link.classList.contains("close-nav")) {
+            e.preventDefault();
+          }
+          nav.classList.remove("open");
+          menuToggle.setAttribute("aria-expanded", "false");
+        });
+      });
+
+      document.querySelectorAll(".download-vcard").forEach((link) => {
+        link.addEventListener("click", triggerVCard);
+      });
+
+      // Read more toggle
+      const readMoreBtn = document.querySelector(".read-more");
+      const moreText = document.querySelector(".more-text");
+      if (readMoreBtn && moreText) {
+        readMoreBtn.addEventListener("click", () => {
+          const expanded = readMoreBtn.getAttribute("aria-expanded") === "true";
+          readMoreBtn.setAttribute("aria-expanded", (!expanded).toString());
+          moreText.classList.toggle("open");
+          readMoreBtn.textContent = expanded ? "Read more" : "Read less";
+        });
       }
-      nav.classList.remove('open');
-      menuToggle.setAttribute('aria-expanded', 'false');
-    });
-  });
 
-  document.querySelectorAll('.download-vcard').forEach(link => {
-    link.addEventListener('click', triggerVCard);
-  });
+      // Animate lists on scroll
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              entry.target.classList.add("in-view");
+              observer.unobserve(entry.target);
+            }
+          });
+        },
+        { threshold: 0.1 },
+      );
 
-  // Read more toggle
-  const readMoreBtn = document.querySelector('.read-more');
-  const moreText = document.querySelector('.more-text');
-  if (readMoreBtn && moreText) {
-    readMoreBtn.addEventListener('click', () => {
-      const expanded = readMoreBtn.getAttribute('aria-expanded') === 'true';
-      readMoreBtn.setAttribute('aria-expanded', (!expanded).toString());
-      moreText.classList.toggle('open');
-      readMoreBtn.textContent = expanded ? 'Read more' : 'Read less';
-    });
-  }
+      document.querySelectorAll(".styled-list li").forEach((item) => {
+        item.classList.add("fade-in");
+        observer.observe(item);
+      });
 
-  // Animate lists on scroll
-  const observer = new IntersectionObserver(entries => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        entry.target.classList.add('in-view');
-        observer.unobserve(entry.target);
-      }
-    });
-  }, { threshold: 0.1 });
-
-  document.querySelectorAll('.styled-list li').forEach(item => {
-    item.classList.add('fade-in');
-    observer.observe(item);
-  });
-
-  const backToTopBtn = document.getElementById('back-to-top');
-  window.addEventListener('scroll', () => {
-    if (window.scrollY > 400) backToTopBtn.classList.add('show');
-    else backToTopBtn.classList.remove('show');
-  });
-  backToTopBtn.addEventListener('click', (e) => {
-    e.preventDefault();
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  });
-</script>
-
-</body>
+      const backToTopBtn = document.getElementById("back-to-top");
+      window.addEventListener("scroll", () => {
+        if (window.scrollY > 400) backToTopBtn.classList.add("show");
+        else backToTopBtn.classList.remove("show");
+      });
+      backToTopBtn.addEventListener("click", (e) => {
+        e.preventDefault();
+        window.scrollTo({ top: 0, behavior: "smooth" });
+      });
+    </script>
+  </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,7 @@
 /* Ensure padding and borders are included in element width */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
@@ -422,7 +424,9 @@ h2 {
 .fade-in {
   opacity: 0;
   transform: translateY(20px);
-  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+  transition:
+    opacity 0.6s ease-out,
+    transform 0.6s ease-out;
 }
 .fade-in.in-view {
   opacity: 1;
@@ -533,7 +537,6 @@ h2 {
     flex-direction: column;
   }
 }
-
 
 .experience .job {
   margin-bottom: 1.5rem;
@@ -664,7 +667,7 @@ blockquote cite {
 
 /* Footer */
 footer {
-  background: #1C2A24;
+  background: #1c2a24;
   color: #fff;
   padding: 2rem 1.25rem;
   font-size: 0.875rem;
@@ -789,59 +792,314 @@ footer a {
   }
 }
 /* === Enhancements added === */
-.skip-link {position:absolute;left:-999px;top:auto;width:1px;height:1px;overflow:hidden;}
-.skip-link:focus {position:static;width:auto;height:auto;padding:.5rem 1rem;background:var(--vi-gold);color:#000;}
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+.skip-link:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: 0.5rem 1rem;
+  background: var(--vi-gold);
+  color: #000;
+}
 
-.breadcrumb {max-width:1100px;margin:0 auto;padding:.75rem 1.25rem;font-size:.875rem;color:var(--vi-5);}
-.breadcrumb a {color:var(--vi-5);text-decoration:underline;}
-.breadcrumb [aria-current="page"] {color:#fff;font-weight:600;}
+.breadcrumb {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0.75rem 1.25rem;
+  font-size: 0.875rem;
+  color: var(--vi-5);
+}
+.breadcrumb a {
+  color: var(--vi-5);
+  text-decoration: underline;
+}
+.breadcrumb [aria-current="page"] {
+  color: #fff;
+  font-weight: 600;
+}
 
-.hero-actions {margin-top:1rem;display:flex;gap:.5rem;flex-wrap:wrap;}
+.hero-actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
 
-.hero-links {margin-top:1rem;display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;}
-.hero-links a {color:var(--vi-5);text-decoration:underline;font-weight:600;}
+.hero-links {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.hero-links a {
+  color: var(--vi-5);
+  text-decoration: underline;
+  font-weight: 600;
+}
 
-.attorney-card {display:grid;grid-template-columns:100px 1fr;gap:1rem;align-items:center;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.1);padding:1rem;border-radius:8px;max-width:900px;margin:1rem 0;}
-.attorney-card img {width:100%;height:auto;border-radius:8px;}
-.attorney-card__content h3 {margin:0 0 .5rem;}
+.desktop-only {
+  display: none;
+}
+@media (min-width: 768px) {
+  .hero-actions.desktop-only,
+  .hero-links.desktop-only {
+    display: flex;
+  }
+}
 
-.compliance-note {max-width:1100px;margin:1rem auto 0;padding:0 1.25rem;color:var(--vi-5);font-size:.875rem;}
+.mobile-hero-links {
+  display: none;
+  background: var(--vi-gray);
+  padding: 1rem 0;
+}
+.mobile-hero-links .hero-actions,
+.mobile-hero-links .hero-links {
+  justify-content: center;
+}
+@media (max-width: 767px) {
+  .mobile-hero-links {
+    display: block;
+  }
+}
 
-.mobile-cta {position:fixed;left:0;right:0;bottom:0;display:flex;gap:.5rem;justify-content:center;padding:.75rem;background:var(--vi-1);z-index:9999;box-shadow:0 -2px 8px rgba(0,0,0,.35);}
-.mobile-cta a {color:#fff;text-decoration:none;font-weight:700;border:1px solid rgba(255,255,255,.3);padding:.6rem 1rem;border-radius:4px;}
-@media(min-width:768px){.mobile-cta{display:none}}
+.section-title-left {
+  text-align: left;
+}
+
+.contact-section {
+  background: #193740;
+  color: #fff;
+  margin-top: -1rem;
+}
+.contact-section a {
+  color: #fff;
+  text-decoration: underline;
+}
+.contact-subtitle {
+  color: var(--vi-1);
+  margin-top: 0;
+}
+
+.attorney-card {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 1rem;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 1rem;
+  border-radius: 8px;
+  max-width: 900px;
+  margin: 1rem 0;
+}
+.attorney-card img {
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+}
+.attorney-card__content h3 {
+  margin: 0 0 0.5rem;
+}
+
+.compliance-note {
+  max-width: 1100px;
+  margin: 1rem auto 0;
+  padding: 0 1.25rem;
+  color: var(--vi-5);
+  font-size: 0.875rem;
+}
+
+.mobile-cta {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  padding: 0.75rem;
+  background: var(--vi-1);
+  z-index: 9999;
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.35);
+}
+.mobile-cta a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: 700;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  padding: 0.6rem 1rem;
+  border-radius: 4px;
+}
+@media (min-width: 768px) {
+  .mobile-cta {
+    display: none;
+  }
+}
 
 /* Timeline */
-.timeline {list-style:none;margin:0;padding:0;}
-.timeline-item {margin:1.5rem 0;padding-left:1rem;border-left:3px solid var(--vi-gold);}
-.timeline-item summary {font-weight:600;cursor:pointer;list-style:none;}
-.timeline-item summary::-webkit-details-marker{display:none;}
-.timeline-item .company {color:var(--vi-gold);}
-.timeline-item .dates {float:right;color:var(--vi-5);font-size:.875rem;}
-.timeline-item p + p {text-indent:1rem;}
-.timeline-item ul {margin-top:.5rem;}
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.timeline-item {
+  margin: 1.5rem 0;
+  padding-left: 1rem;
+  border-left: 3px solid var(--vi-gold);
+}
+.timeline-item summary {
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+}
+.timeline-item summary::-webkit-details-marker {
+  display: none;
+}
+.timeline-item .company {
+  color: var(--vi-1);
+}
+.timeline-item .dates {
+  float: right;
+  color: var(--vi-5);
+  font-size: 0.875rem;
+}
 
-a.back-to-top {display:block;margin-top:1rem;text-align:right;font-size:.875rem;}
+.section-divider.full-width {
+  width: 100%;
+}
 
-.section-divider {border:0;height:2px;background:var(--vi-gold);width:80%;margin:2rem auto;}
+#education .styled-list li {
+  border-left: none;
+  padding-left: 0;
+}
+#education .styled-list {
+  margin-left: 0;
+  padding-left: 0;
+}
 
-.education-grid {display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;}
-.education-grid li {display:flex;align-items:flex-start;padding:.5rem;}
-.courses summary {cursor:pointer;font-weight:600;}
+.bg-dark-gray {
+  background: #333;
+  color: #fff;
+}
+.bg-dark-gray a {
+  color: #fff;
+  text-decoration: underline;
+}
 
-.admissions-list {column-count:2;column-gap:1rem;}
-.admissions-list li {break-inside:avoid;padding:.25rem 0;}
+.admissions-grid {
+  display: grid;
+  gap: 1rem;
+}
+@media (min-width: 600px) {
+  .admissions-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+#admissions .admissions-list {
+  column-count: 1;
+}
 
-.license-list {border:1px solid var(--vi-4);padding:1rem;}
-.license-list ul {list-style:none;margin:0;padding:0;}
-.license-list li {padding:.5rem;}
-.license-list li:nth-child(even){background:var(--vi-gray);}
-.license-type {margin-top:1rem;font-weight:600;}
+#licenses .license-list {
+  border: none;
+}
+.timeline-item p + p {
+  text-indent: 1rem;
+}
+.timeline-item ul {
+  margin-top: 0.5rem;
+}
 
-.section-title {transition:color .3s;}
-.section-title:hover {color:var(--vi-gold);}
+a.back-to-top {
+  display: block;
+  margin-top: 1rem;
+  text-align: right;
+  font-size: 0.875rem;
+}
 
-.why-list {max-width:600px;margin:0 auto;text-align:left;}
+.section-divider {
+  border: 0;
+  height: 2px;
+  background: var(--vi-gold);
+  width: 80%;
+  margin: 2rem auto;
+}
 
-#back-to-top {position:fixed;bottom:1rem;right:1rem;background:var(--vi-gold);color:#000;padding:.5rem .75rem;border-radius:4px;text-decoration:none;display:none;}
-#back-to-top.show {display:block;}
+.education-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+.education-grid li {
+  display: flex;
+  align-items: flex-start;
+  padding: 0.5rem;
+}
+.courses summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.admissions-list {
+  column-count: 2;
+  column-gap: 1rem;
+}
+.admissions-list li {
+  break-inside: avoid;
+  padding: 0.25rem 0;
+}
+
+.license-list {
+  border: 1px solid var(--vi-4);
+  padding: 1rem;
+}
+.license-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.license-list li {
+  padding: 0.5rem;
+}
+.license-list li:nth-child(even) {
+  background: var(--vi-gray);
+}
+.license-type {
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
+.section-title {
+  transition: color 0.3s;
+}
+.section-title:hover {
+  color: var(--vi-gold);
+}
+
+.why-list {
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+#back-to-top {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: var(--vi-gold);
+  color: #000;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  text-decoration: none;
+  display: none;
+}
+#back-to-top.show {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- Display hero actions and navigation links below the hero on mobile while keeping desktop layout intact
- Restyle Contact, Professional Summary, Legal Experience, Education, Admissions & Courts, and Additional Licenses sections with new colors, alignment, and open accordions
- Introduce dark and light gray backgrounds, improved heading alignment, and two-column admissions list

## Testing
- `npx prettier -w about.html styles.css`
- `npx -y htmlhint about.html`

------
https://chatgpt.com/codex/tasks/task_e_6896e656f7708321abae9a281b44a964