### PR TITLE
feat: add padding to about page contact section

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1120,7 +1120,7 @@ a.back-to-top {
 /* ===== Contact band, full-width teal ===== */
 .contact-band{
   position: relative;
-  padding: 0;
+  padding: clamp(1.5rem, 4vw, 3rem) 0;
   isolation: isolate;
 }
 .contact-band::before{


### PR DESCRIPTION
## Summary
- add vertical padding to About page contact band for better spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896f52d47808321b2a4914aea6f1d91