### PR TITLE
Add sticky mobile quick subnav to About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -138,22 +138,16 @@
           </div>
         </div>
       </section>
-
-      <div class="mobile-hero-links">
-        <div class="hero-actions">
-          <a href="#about" class="btn">Meet Robert</a>
-          <a href="contact.html" class="btn btn-secondary">Contact</a>
-        </div>
-        <div class="hero-links">
-          <a href="#about">About</a>
-          <a href="#experience">Experience</a>
-          <a href="#education">Education</a>
-          <a href="#admissions">Admissions</a>
-          <a href="#licenses">Licenses</a>
-          <a href="#approach">Approach</a>
-          <a href="#contact-info">Contact</a>
-        </div>
-      </div>
+      <!-- Mobile quick links, sticky -->
+      <nav id="about-subnav" class="mobile-subnav" aria-label="Quick section links">
+        <a class="subnav-chip" href="#about">About</a>
+        <a class="subnav-chip" href="#experience">Experience</a>
+        <a class="subnav-chip" href="#education">Education</a>
+        <a class="subnav-chip" href="#admissions">Admissions</a>
+        <a class="subnav-chip" href="#licenses">Licenses</a>
+        <a class="subnav-chip" href="#approach">Approach</a>
+        <a class="subnav-chip" href="#contact-info">Contact</a>
+      </nav>
 
       <section class="bg-white" id="about">
         <h2 class="section-title section-title-left">Meet Attorney Pohl</h2>
@@ -813,6 +807,47 @@
         e.preventDefault();
         window.scrollTo({ top: 0, behavior: "smooth" });
       });
+    </script>
+
+    <script>
+      /* About: highlight active chip as sections enter view, keep chip centered */
+      (function () {
+        const subnav = document.getElementById("about-subnav");
+        if (!subnav) return;
+
+        const chips = Array.from(subnav.querySelectorAll("a.subnav-chip"));
+        const map = new Map(chips.map((a) => [a.getAttribute("href"), a]));
+        const sections = chips
+          .map((a) => document.querySelector(a.getAttribute("href")))
+          .filter(Boolean);
+
+        function setActive(id) {
+          chips.forEach((c) => c.removeAttribute("aria-current"));
+          const active = map.get(id);
+          if (active) {
+            active.setAttribute("aria-current", "page");
+            // keep the active chip in view on small screens
+            active.scrollIntoView({
+              behavior: "smooth",
+              inline: "center",
+              block: "nearest",
+            });
+          }
+        }
+
+        const io = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              if (entry.isIntersecting) {
+                setActive("#" + entry.target.id);
+              }
+            });
+          },
+          { root: null, rootMargin: "-45% 0px -45% 0px", threshold: 0.01 },
+        );
+
+        sections.forEach((sec) => io.observe(sec));
+      })();
     </script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1285,3 +1285,48 @@ a.back-to-top {
 
 /* tighten the built-in section title here only */
 #contact-info .section-title{ margin-bottom: .25rem; }
+
+/* ===== Mobile quick subnav for About ===== */
+#about-subnav{
+  display: flex;
+  gap: .5rem;
+  padding: .5rem .75rem;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  background: rgba(255,255,255,.92);
+  border-bottom: 1px solid rgba(19,35,38,.08);
+  box-shadow: 0 2px 10px rgba(0,0,0,.06);
+  backdrop-filter: saturate(120%) blur(6px);
+  /* soft edge fades */
+  mask-image: linear-gradient(to right, transparent 0, #000 12px, #000 calc(100% - 12px), transparent 100%);
+}
+#about-subnav::-webkit-scrollbar{ display:none; }
+
+#about-subnav .subnav-chip{
+  flex: 0 0 auto;
+  white-space: nowrap;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: .95rem;
+  line-height: 1;
+  padding: .6rem .9rem;
+  border-radius: 999px;
+  background: #fff;
+  color: #132326;
+  border: 1px solid rgba(19,35,38,.18);
+}
+#about-subnav .subnav-chip:hover{ background: #f6f8f9; }
+#about-subnav .subnav-chip[aria-current="page"]{
+  background: #14383d;        /* site teal */
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 4px 10px rgba(20,56,61,.25);
+}
+
+/* Show only on mobile */
+@media (min-width: 900px){
+  #about-subnav{ display:none; }
+}


### PR DESCRIPTION
## Summary
- Replace old mobile links with a sticky quick-nav on About page.
- Style scrollable pill links and highlight active section.
- Add JS to track section visibility and center active link.

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_6896f8b4367c83218e9d30ec54d2b092