### PR TITLE
feat: add desktop toolbar to About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -138,6 +138,33 @@
           </div>
         </div>
       </section>
+      <!-- Desktop toolbar below hero -->
+      <div class="about-toolbar desktop-only" role="navigation" aria-label="About quick links">
+        <div class="about-toolbar__inner">
+          <!-- tiny ghosted logo -->
+          <img
+            class="toolbar-logo"
+            src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8dd67803-ace6-499b-f07e-3aa217afcf00/public"
+            alt=""
+            aria-hidden="true"
+            width="96"
+            height="54"
+            decoding="async"
+          />
+
+          <a href="contact.html" class="btn toolbar-cta">Free Consultation</a>
+
+          <nav id="about-subnav-desktop" class="chip-nav" aria-label="About section links">
+            <a class="subnav-chip" href="#about">About</a>
+            <a class="subnav-chip" href="#experience">Experience</a>
+            <a class="subnav-chip" href="#education">Education</a>
+            <a class="subnav-chip" href="#admissions">Admissions</a>
+            <a class="subnav-chip" href="#licenses">Licenses</a>
+            <a class="subnav-chip" href="#approach">Approach</a>
+            <a class="subnav-chip" href="#contact-info">Contact</a>
+          </nav>
+        </div>
+      </div>
       <!-- Mobile quick links, sticky -->
       <nav id="about-subnav" class="mobile-subnav" aria-label="Quick section links">
         <a class="subnav-chip" href="#about">About</a>
@@ -810,37 +837,44 @@
     </script>
 
     <script>
-      /* About: highlight active chip as sections enter view, keep chip centered */
+      /* About: highlight active chip across mobile and desktop chips */
       (function () {
-        const subnav = document.getElementById("about-subnav");
-        if (!subnav) return;
+        const containers = [
+          document.getElementById("about-subnav"),
+          document.getElementById("about-subnav-desktop"),
+        ].filter(Boolean);
 
-        const chips = Array.from(subnav.querySelectorAll("a.subnav-chip"));
-        const map = new Map(chips.map((a) => [a.getAttribute("href"), a]));
-        const sections = chips
-          .map((a) => document.querySelector(a.getAttribute("href")))
-          .filter(Boolean);
+        if (!containers.length) return;
+
+        const chipSets = containers.map((c) =>
+          Array.from(c.querySelectorAll("a.subnav-chip"))
+        );
+        const chips = chipSets.flat();
+        const map = new Map(
+          chips.map((a) => [
+            a.getAttribute("href"),
+            chips.filter((x) => x.getAttribute("href") === a.getAttribute("href")),
+          ])
+        );
+
+        const sections = [
+          ...new Set(
+            chips
+              .map((a) => document.querySelector(a.getAttribute("href")))
+              .filter(Boolean),
+          ),
+        ];
 
         function setActive(id) {
           chips.forEach((c) => c.removeAttribute("aria-current"));
-          const active = map.get(id);
-          if (active) {
-            active.setAttribute("aria-current", "page");
-            // keep the active chip in view on small screens
-            active.scrollIntoView({
-              behavior: "smooth",
-              inline: "center",
-              block: "nearest",
-            });
-          }
+          const group = map.get(id);
+          if (group) group.forEach((c) => c.setAttribute("aria-current", "page"));
         }
 
         const io = new IntersectionObserver(
           (entries) => {
             entries.forEach((entry) => {
-              if (entry.isIntersecting) {
-                setActive("#" + entry.target.id);
-              }
+              if (entry.isIntersecting) setActive("#" + entry.target.id);
             });
           },
           { root: null, rootMargin: "-45% 0px -45% 0px", threshold: 0.01 },

--- a/styles.css
+++ b/styles.css
@@ -1330,3 +1330,84 @@ a.back-to-top {
 @media (min-width: 900px){
   #about-subnav{ display:none; }
 }
+
+/* Desktop toolbar layout, with tiny ghosted logo on the left */
+.about-toolbar {
+  position: sticky;
+  top: 0; /* adjust if your site header is sticky with a custom height */
+  z-index: 40;
+  background: #ffffff;
+  border-bottom: 1px solid rgba(19, 35, 38, 0.08);
+  box-shadow: 0 4px 16px rgba(0,0,0,0.06);
+}
+.about-toolbar__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: .75rem 1rem;
+  display: grid;
+  grid-template-columns: auto auto 1fr; /* logo, CTA, chips */
+  gap: 1rem;
+  align-items: center;
+}
+
+/* tiny bird */
+.toolbar-logo{
+  width: clamp(28px, 2.6vw, 44px);
+  height: auto;
+  opacity: .38;
+  filter: grayscale(1) contrast(90%) brightness(105%);
+  user-select: none;
+  pointer-events: none;
+}
+
+/* CTA stays compact */
+.toolbar-cta { white-space: nowrap; }
+
+/* Chip nav matches mobile pills, tuned for desktop */
+.chip-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem;
+  justify-content: flex-end;
+  align-items: center;
+  min-height: 2.25rem;
+}
+.subnav-chip {
+  display: inline-flex;
+  align-items: center;
+  height: 2.25rem;
+  padding: 0 .9rem;
+  border-radius: 999px;
+  background: #f4f6f7;
+  color: #132326;
+  font-size: .95rem;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: background .2s, border-color .2s, color .2s;
+}
+.subnav-chip:hover { background: #e8eef0; }
+.subnav-chip[aria-current="page"] {
+  background: #1b3b42; /* site teal family */
+  color: #fff;
+}
+
+/* Single line compression on wide screens */
+@media (min-width: 1200px){
+  .chip-nav { flex-wrap: nowrap; gap: .4rem; }
+  .subnav-chip { height: 2rem; padding: 0 .75rem; font-size: .92rem; }
+  .about-toolbar__inner { gap: .75rem; }
+}
+@media (min-width: 1440px){
+  /* relax spacing again when there is room */
+  .chip-nav { gap: .5rem; }
+  .subnav-chip { height: 2.1rem; padding: 0 .8rem; font-size: .94rem; }
+}
+
+/* Keep desktop items off on small screens */
+.desktop-only { display: none; }
+@media (min-width: 992px){
+  .desktop-only { display: block; }
+  /* ensure nothing leaks into the hero on desktop */
+  .hero.hero-about .hero-actions,
+  .hero.hero-about .hero-links { display: none !important; }
+}


### PR DESCRIPTION
## Summary
- add sticky desktop toolbar with logo and consolidated quick links
- style toolbar layout and interactions
- sync chip highlighting between mobile and desktop subnavs

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6897001f5f408321968e2115e74dd3ef