### PR TITLE
Refine About page structure and styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -129,12 +129,8 @@
         </div>
       </section>
 
-      <!-- Sticky Desktop Toolbar with Quick Links -->
-      <div
-        class="about-toolbar desktop-only"
-        role="navigation"
-        aria-label="About quick links"
-      >
+      <!-- Desktop toolbar below hero -->
+      <div class="about-toolbar desktop-only" role="navigation" aria-label="About quick links">
         <div class="about-toolbar__inner">
           <img
             class="toolbar-logo"
@@ -144,12 +140,7 @@
             width="96"
             height="54"
           />
-          <a href="contact.html" class="btn toolbar-cta">Free Consultation</a>
-          <nav
-            id="about-subnav-desktop"
-            class="chip-nav"
-            aria-label="About section links"
-          >
+          <nav id="about-subnav-desktop" class="chip-nav" aria-label="About section links">
             <a class="subnav-chip" href="#about">About</a>
             <a class="subnav-chip" href="#experience">Experience</a>
             <a class="subnav-chip" href="#education">Education</a>
@@ -623,53 +614,59 @@
 
       <hr class="section-divider" aria-hidden="true" />
 
-      <!-- Education Section -->
+      <!-- Education -->
       <div class="info-section bg-white" id="education">
         <h2 class="section-title-left">Education</h2>
-        <p class="education-blurb">
-          Highlights of Robert's academic background.
-        </p>
-        <ul class="styled-list education-grid">
-          <li>
-            LL.M., Taxation <em>(Cum Laude)</em> – University of San Diego
-            School of Law, 2000
-          </li>
-          <li>Juris Doctor – University of San Diego School of Law, 1999</li>
-          <li>
-            MBA, International Business – University of San Diego Graduate
-            Business School, 1999
-          </li>
-          <li>
-            <em>Merit Certificate</em>, International Corporate Structure –
-            Institute on International &amp; Comparative Law, Paris, 1996
-          </li>
-          <li>
-            Baccalaureus Artium, English Literature – Boston College, 1991
-          </li>
-          <li>
-            <em>Merit Certificate</em>, English Literature – Harris Manchester
-            College, Oxford University, 1990
-          </li>
-        </ul>
+        <p class="education-blurb">Highlights of Robert’s academic background.</p>
+
+        <div class="edu-grid">
+          <article class="edu-card">
+            <h3>Law</h3>
+            <ul class="styled-list">
+              <li>LL.M., Taxation (Cum Laude), University of San Diego School of Law, 2000</li>
+              <li>Juris Doctor, University of San Diego School of Law, 1999</li>
+            </ul>
+          </article>
+
+          <article class="edu-card">
+            <h3>Business</h3>
+            <ul class="styled-list">
+              <li>MBA, International Business, University of San Diego Graduate Business School, 1999</li>
+            </ul>
+          </article>
+
+          <article class="edu-card">
+            <h3>International Study</h3>
+            <ul class="styled-list">
+              <li>Merit Certificate, International Corporate Structure, Institute on International &amp; Comparative Law, Paris, 1996</li>
+            </ul>
+          </article>
+
+          <article class="edu-card">
+            <h3>Undergraduate</h3>
+            <ul class="styled-list">
+              <li>Baccalaureus Artium, English Literature, Boston College, 1991</li>
+              <li>Merit Certificate, English Literature, Harris Manchester College, Oxford University, 1990</li>
+            </ul>
+          </article>
+        </div>
+
         <details class="courses" open>
           <summary>Courses &amp; Certifications</summary>
           <ul class="styled-list">
-            <li>Bankruptcy Law Workshop – ABA, 2023</li>
-            <li>Certified Mediator Training – 2021</li>
+            <li>Bankruptcy Law Workshop, ABA, 2023</li>
+            <li>Certified Mediator Training, 2021</li>
           </ul>
         </details>
-        <a href="cv.pdf" class="btn" download>Download CV</a>
       </div>
 
-      <!-- Admissions & Courts Section -->
-      <div class="info-section bg-dark-gray" id="admissions">
-        <h2 class="section-title section-title-left">
-          Admissions &amp; Courts
-        </h2>
-        <div class="admissions-grid">
-          <div>
+      <!-- Admissions & Courts, restyled to match index cards -->
+      <section class="bg-gray" id="admissions">
+        <h2 class="section-title">Admissions &amp; Courts</h2>
+        <div class="services services--tight">
+          <div class="service-card">
             <h3>Admissions</h3>
-            <ul class="styled-list admissions-list">
+            <ul class="styled-list">
               <li>California (2000)</li>
               <li>District of Columbia (2002)</li>
               <li>Tennessee (2008)</li>
@@ -677,9 +674,9 @@
               <li>South Carolina (2010)</li>
             </ul>
           </div>
-          <div>
+          <div class="service-card">
             <h3>Courts</h3>
-            <ul class="styled-list admissions-list">
+            <ul class="styled-list">
               <li>United States Federal Courts (2000)</li>
               <li>United States Tax Court (2000)</li>
               <li>United States Supreme Court (2006)</li>
@@ -687,7 +684,7 @@
             </ul>
           </div>
         </div>
-      </div>
+      </section>
 
       <!-- Additional Licenses Section -->
       <div class="info-section" id="licenses">

--- a/styles.css
+++ b/styles.css
@@ -1471,3 +1471,93 @@ a.back-to-top {
     display: block;
   }
 }
+
+/* About toolbar, no CTA version */
+.about-toolbar__inner{
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: .75rem 1rem;
+  display: grid;
+  grid-template-columns: auto 1fr; /* logo, chips */
+  gap: .75rem 1rem;
+  align-items: center;
+}
+
+/* Keep chips tidy when very wide */
+@media (min-width: 1200px){
+  .chip-nav { flex-wrap: nowrap; gap: .45rem; }
+  .subnav-chip { height: 2rem; padding: 0 .75rem; font-size: .92rem; }
+}
+
+/* Education, premium cards */
+.edu-grid{
+  display: grid;
+  gap: clamp(0.9rem, 2vw, 1.25rem);
+  grid-template-columns: 1fr;
+}
+@media (min-width: 900px){
+  .edu-grid{ grid-template-columns: 1fr 1fr; }
+}
+.edu-card{
+  background: #fff;
+  border: 1px solid rgba(19,35,38,.12);
+  border-radius: 14px;
+  padding: clamp(.9rem, 2.2vw, 1.25rem);
+  box-shadow: 0 10px 24px rgba(0,0,0,.06);
+}
+.edu-card h3{
+  margin: 0 0 .35rem 0;
+  font-size: 1.05rem;
+}
+
+/* Remove the old CV button space if any rules targeted it */
+#education .btn[download]{ display: none; }
+
+/* Admissions uses home page card system, tighten the grid a touch on desktop */
+.services--tight{
+  gap: clamp(0.9rem, 2vw, 1.25rem);
+  align-items: stretch;
+}
+.services--tight .service-card{
+  padding: clamp(.9rem, 2.2vw, 1.25rem);
+}
+
+/* Desktop breathing room, increase rhythm where things felt cramped */
+#about .about-wrapper,
+#summary .summary-content,
+.experience-wrapper .info-section,
+#education,
+#admissions,
+#licenses,
+#approach{
+  --pad-y: clamp(2.25rem, 4vw, 4rem);
+  padding-top: var(--pad-y);
+  padding-bottom: var(--pad-y);
+}
+.info-section,
+section.bg-white,
+section.bg-gray{ 
+  /* ensure consistent max width and center */
+  max-width: 1100px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Readability tweaks */
+.info-section p,
+.timeline p{ line-height: 1.65; }
+.styled-list li{ margin: .35rem 0; }
+
+/* Timeline spacing */
+.timeline{ gap: 1rem; }
+.timeline-item summary{
+  padding: .65rem .9rem;
+  border-radius: 10px;
+}
+.timeline-item > p{ margin: .5rem 0 0; }
+
+/* Make the hero breathe a bit more under the title */
+.hero.hero-about .hero-content p{ max-width: 720px; }
+
+/* If your Admissions old dark box remains elsewhere, neutralize it on this page */
+#admissions.bg-dark-gray{ background: transparent; }


### PR DESCRIPTION
## Summary
- Remove desktop Free Consultation CTA under hero, leaving only logo and quick-link chips.
- Rebuild Education into card grid and drop CV button for a lighter look.
- Restyle Admissions using existing service-card pattern and loosen overall spacing.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68970ffe2c4483219e8438dac1f0edf1