### PR TITLE
Remove breadcrumb navigation from bankruptcy pages

### DIFF
--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -57,13 +57,6 @@
       <a href="#" class="mobile-only close-nav" data-icon="❌">Close</a>
     </nav>
   </header>
-
-  <nav class="breadcrumb" aria-label="Breadcrumb">
-    <a href="index.html">Home</a> <span> › </span>
-    <a href="index.html#services">Services</a> <span> › </span>
-    <span aria-current="page">Business Bankruptcy</span>
-  </nav>
-
   <main id="main">
 
   <section class="hero hero-business">

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -73,12 +73,6 @@
     </nav>
   </header>
 
-  <nav class="breadcrumb" aria-label="Breadcrumb">
-    <a href="index.html">Home</a> <span> › </span>
-    <a href="index.html#services">Services</a> <span> › </span>
-    <span aria-current="page">Personal Bankruptcy</span>
-  </nav>
-
   <main id="main">
 
   <section class="hero hero-personal">

--- a/styles.css
+++ b/styles.css
@@ -808,22 +808,6 @@ footer a {
   color: #000;
 }
 
-.breadcrumb {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 0.75rem 1.25rem;
-  font-size: 0.875rem;
-  color: var(--vi-5);
-}
-.breadcrumb a {
-  color: var(--vi-5);
-  text-decoration: underline;
-}
-.breadcrumb [aria-current="page"] {
-  color: #fff;
-  font-weight: 600;
-}
-
 .hero-actions {
   margin-top: 1rem;
   display: flex;


### PR DESCRIPTION
## Summary
- Remove breadcrumb navigation from personal and business bankruptcy pages so main content starts immediately after the header
- Delete unused breadcrumb styles from global stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68978b883d6c8321a9d08553d39372f9