### PR TITLE
Enable email delivery from contact form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -89,22 +89,24 @@
         </div>
       </div>
       <div>
-        <form id="consult-form" onsubmit="handleSubmit(event)">
+        <form id="consult-form" action="https://formsubmit.co/robert@pohlbankruptcy.com" method="POST" onsubmit="handleSubmit(event)">
+          <input type="hidden" name="_cc" value="davidlegal1975@pm.me" />
+          <input type="hidden" name="_captcha" value="false" />
           <div class="form-group">
             <label for="name">Name</label>
-            <input id="name" type="text" required />
+            <input id="name" name="name" type="text" required />
           </div>
           <div class="form-group">
             <label for="email">Email</label>
-            <input id="email" type="email" required />
+            <input id="email" name="email" type="email" required />
           </div>
           <div class="form-group">
             <label for="phone">Phone</label>
-            <input id="phone" type="tel" />
+            <input id="phone" name="phone" type="tel" />
           </div>
           <div class="form-group">
             <label for="message">Message</label>
-            <textarea id="message"></textarea>
+            <textarea id="message" name="message"></textarea>
           </div>
           <button class="btn form-submit" type="submit">Submit</button>
           <small class="confidential-note"><em>Your information is confidential. We will review your message and get back to you within one business day.</em></small>
@@ -123,10 +125,24 @@
   </footer>
 
   <script>
-    function handleSubmit(e) {
+    async function handleSubmit(e) {
       e.preventDefault();
-      document.getElementById('consult-form').style.display = 'none';
-      document.getElementById('thank-you').style.display = 'block';
+      const form = document.getElementById('consult-form');
+      const formData = new FormData(form);
+      try {
+        const response = await fetch('https://formsubmit.co/ajax/robert@pohlbankruptcy.com', {
+          method: 'POST',
+          body: formData
+        });
+        if (response.ok) {
+          form.style.display = 'none';
+          document.getElementById('thank-you').style.display = 'block';
+        } else {
+          alert('There was a problem sending your message. Please try again later.');
+        }
+      } catch (err) {
+        alert('There was a problem sending your message. Please try again later.');
+      }
     }
   </script>
 

--- a/styles.css
+++ b/styles.css
@@ -1545,3 +1545,6 @@ section.bg-gray{
 
 /* If your Admissions old dark box remains elsewhere, neutralize it on this page */
 #admissions.bg-dark-gray{ background: transparent; }
+#thank-you {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Send contact form submissions via FormSubmit to robert@pohlbankruptcy.com and cc davidlegal1975@pm.me
- Hide thank-you message until submission and post form data asynchronously

## Testing
- `curl -H 'Referer: https://vibankruptcy.com/contact.html' -X POST https://formsubmit.co/ajax/robert@pohlbankruptcy.com -H 'Content-Type: application/json' -d '{"name":"Test","email":"test@example.com","message":"hi"}'`

------
https://chatgpt.com/codex/tasks/task_e_68995f1c758083218db289d43333b5c8