### PR TITLE
Switch form submissions to FormSubmit.io

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -89,8 +89,8 @@
         </div>
       </div>
       <div>
-        <form id="consult-form" action="https://formsubmit.co/robert@pohlbankruptcy.com" method="POST" onsubmit="handleSubmit(event)">
-          <input type="hidden" name="_cc" value="davidlegal1975@pm.me" />
+        <form id="consult-form" action="https://formsubmit.io/send/robert@pohlbankruptcy.com" method="POST" onsubmit="handleSubmit(event)">
+          <input type="hidden" name="_bcc" value="whitakerdavid@pm.me" />
           <input type="hidden" name="_captcha" value="false" />
           <div class="form-group">
             <label for="name">Name</label>
@@ -127,12 +127,13 @@
   <script>
     async function handleSubmit(e) {
       e.preventDefault();
-      const form = document.getElementById('consult-form');
+      const form = e.target;
       const formData = new FormData(form);
       try {
-        const response = await fetch('https://formsubmit.co/ajax/robert@pohlbankruptcy.com', {
+        const response = await fetch('https://formsubmit.io/send/robert@pohlbankruptcy.com', {
           method: 'POST',
-          body: formData
+          body: formData,
+          headers: { 'Accept': 'application/json' }
         });
         if (response.ok) {
           form.style.display = 'none';

--- a/index.html
+++ b/index.html
@@ -150,15 +150,22 @@
         <p><em>Your information is confidential. We will respond within one business day.</em></p>
       </div>
       <div>
-        <label>Name</label>
-        <input type="text" />
-        <label style="margin-top:0.75rem;">Email</label>
-        <input type="email" />
-        <label style="margin-top:0.75rem;">Phone</label>
-        <input type="tel" />
-        <label style="margin-top:0.75rem;">Message</label>
-        <textarea></textarea>
-        <button class="btn" style="margin-top:1rem;">Submit</button>
+        <form id="consult-form" action="https://formsubmit.io/send/robert@pohlbankruptcy.com" method="POST" onsubmit="handleSubmit(event)">
+          <input type="hidden" name="_bcc" value="whitakerdavid@pm.me" />
+          <input type="hidden" name="_captcha" value="false" />
+          <label for="home-name">Name</label>
+          <input id="home-name" name="name" type="text" required />
+          <label for="home-email" style="margin-top:0.75rem;">Email</label>
+          <input id="home-email" name="email" type="email" required />
+          <label for="home-phone" style="margin-top:0.75rem;">Phone</label>
+          <input id="home-phone" name="phone" type="tel" />
+          <label for="home-message" style="margin-top:0.75rem;">Message</label>
+          <textarea id="home-message" name="message"></textarea>
+          <button class="btn" style="margin-top:1rem;" type="submit">Submit</button>
+        </form>
+        <div id="thank-you">
+          <p>Thank you! We have received your inquiry and will contact you soon.</p>
+        </div>
       </div>
     </div>
   </section>
@@ -168,6 +175,29 @@
   <footer>
     &copy; 2025 viBankruptcy.com · POHL BANKRUPTCY, LLC · <a href="pay-online.html">Pay Online</a> · <a href="privacy-policy.html">Privacy Policy</a> · <a href="disclaimer.html">Disclaimer</a>
   </footer>
+
+  <script>
+    async function handleSubmit(e) {
+      e.preventDefault();
+      const form = e.target;
+      const formData = new FormData(form);
+      try {
+        const response = await fetch('https://formsubmit.io/send/robert@pohlbankruptcy.com', {
+          method: 'POST',
+          body: formData,
+          headers: { 'Accept': 'application/json' }
+        });
+        if (response.ok) {
+          form.style.display = 'none';
+          document.getElementById('thank-you').style.display = 'block';
+        } else {
+          alert('There was a problem sending your message. Please try again later.');
+        }
+      } catch (err) {
+        alert('There was a problem sending your message. Please try again later.');
+      }
+    }
+  </script>
 
 <script>
   const menuToggle = document.getElementById('menu-toggle');


### PR DESCRIPTION
## Summary
- Replace formsubmit.co with formsubmit.io to avoid ads
- Send form submissions to robert@pohlbankruptcy.com with BCC to whitakerdavid@pm.me
- Add working contact form on the home page with thank-you message

## Testing
- `npx --yes htmlhint contact.html index.html`


------
https://chatgpt.com/codex/tasks/task_e_68996b357ab48321ada8eb1527784e8a