### PR TITLE
Ensure contact forms email both attorneys

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -89,8 +89,8 @@
         </div>
       </div>
       <div>
-        <form id="consult-form" action="https://formsubmit.io/send/robert@pohlbankruptcy.com" method="POST" onsubmit="handleSubmit(event)">
-          <input type="hidden" name="_bcc" value="whitakerdavid@pm.me" />
+        <form id="consult-form" action="https://formsubmit.co/robert@pohlbankruptcy.com" method="POST" onsubmit="handleSubmit(event)">
+          <input type="hidden" name="_cc" value="davidlegal1975@pm.me" />
           <input type="hidden" name="_captcha" value="false" />
           <div class="form-group">
             <label for="name">Name</label>
@@ -129,13 +129,20 @@
       e.preventDefault();
       const form = e.target;
       const formData = new FormData(form);
+      const data = Object.fromEntries(formData.entries());
       try {
-        const response = await fetch('https://formsubmit.io/send/robert@pohlbankruptcy.com', {
+        const robert = fetch('https://formsubmit.co/ajax/robert@pohlbankruptcy.com', {
           method: 'POST',
-          body: formData,
-          headers: { 'Accept': 'application/json' }
+          headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+          body: JSON.stringify(data)
         });
-        if (response.ok) {
+        const david = fetch('https://formsubmit.co/ajax/davidlegal1975@pm.me', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+          body: JSON.stringify(data)
+        });
+        const [rRes, dRes] = await Promise.all([robert, david]);
+        if (rRes.ok && dRes.ok) {
           form.style.display = 'none';
           document.getElementById('thank-you').style.display = 'block';
         } else {

--- a/index.html
+++ b/index.html
@@ -150,8 +150,8 @@
         <p><em>Your information is confidential. We will respond within one business day.</em></p>
       </div>
       <div>
-        <form id="consult-form" action="https://formsubmit.io/send/robert@pohlbankruptcy.com" method="POST" onsubmit="handleSubmit(event)">
-          <input type="hidden" name="_bcc" value="whitakerdavid@pm.me" />
+        <form id="consult-form" action="https://formsubmit.co/robert@pohlbankruptcy.com" method="POST" onsubmit="handleSubmit(event)">
+          <input type="hidden" name="_cc" value="davidlegal1975@pm.me" />
           <input type="hidden" name="_captcha" value="false" />
           <label for="home-name">Name</label>
           <input id="home-name" name="name" type="text" required />
@@ -181,13 +181,20 @@
       e.preventDefault();
       const form = e.target;
       const formData = new FormData(form);
+      const data = Object.fromEntries(formData.entries());
       try {
-        const response = await fetch('https://formsubmit.io/send/robert@pohlbankruptcy.com', {
+        const robert = fetch('https://formsubmit.co/ajax/robert@pohlbankruptcy.com', {
           method: 'POST',
-          body: formData,
-          headers: { 'Accept': 'application/json' }
+          headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+          body: JSON.stringify(data)
         });
-        if (response.ok) {
+        const david = fetch('https://formsubmit.co/ajax/davidlegal1975@pm.me', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+          body: JSON.stringify(data)
+        });
+        const [rRes, dRes] = await Promise.all([robert, david]);
+        if (rRes.ok && dRes.ok) {
           form.style.display = 'none';
           document.getElementById('thank-you').style.display = 'block';
         } else {


### PR DESCRIPTION
## Summary
- Update home and contact page forms to send submissions to both robert@pohlbankruptcy.com and davidlegal1975@pm.me
- Switch to FormSubmit’s AJAX endpoint and post to each address simultaneously
- Preserve on-page thank you message and add cc fallback

## Testing
- `yes | npx htmlhint index.html contact.html`

------
https://chatgpt.com/codex/tasks/task_e_68997a8c2c5483219d23e7e6baf06df0