### PR TITLE
Serve icons from site root

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,78 +1,54 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- Favicon and App Icons -->
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="16x16"
-      href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="192x192"
-      href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="512x512"
-      href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public"
-    />
-    <link rel="manifest" href="site.webmanifest" />
-    <meta
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <meta
       name="description"
       content="Learn about Attorney Robert Pohl and how our firm helps Virgin Islanders find financial relief under Chapters 7, 11, 12 &amp; 13."
     />
-    <meta property="og:title" content="About | VI Bankruptcy" />
-    <meta
+  <meta property="og:title" content="About | VI Bankruptcy" />
+  <meta
       property="og:description"
       content="Learn about Attorney Robert Pohl and how our firm helps Virgin Islanders find financial relief under Chapters 7, 11, 12 &amp; 13."
     />
-    <meta
+  <meta
       property="og:image"
       content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public"
     />
-    <meta property="og:url" content="https://vibankruptcy.com/about.html" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta
+  <meta property="og:url" content="https://vibankruptcy.com/about.html" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta
       name="twitter:image"
       content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public"
     />
-    <link rel="canonical" href="https://vibankruptcy.com/about.html" />
-    <meta
+  <link rel="canonical" href="https://vibankruptcy.com/about.html" />
+  <meta
       name="robots"
       content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1"
     />
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="VI Bankruptcy" />
-    <meta property="og:locale" content="en_US" />
-    <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
-    <meta name="theme-color" content="#132326" />
-    <title>About | VI Bankruptcy</title>
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VI Bankruptcy" />
+  <meta property="og:locale" content="en_US" />
+  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <meta name="theme-color" content="#132326" />
+  <title>About | VI Bankruptcy</title>
 
-    <!-- Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
       href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <div id="top"></div>

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
-  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
-  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
-  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
-  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" />
-  <link rel="manifest" href="site.webmanifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Struggling with business debt in St. Thomas, St. John, or St. Croix? Learn how Chapter 11, Subchapter V, or Chapter 7 can protect operations, renegotiate leases, and resolve liabilities. Free consultation." />
   <link rel="canonical" href="https://vibankruptcy.com/business-bankruptcy.html" />
   <meta property="og:title" content="Virgin Islands Business Bankruptcy Lawyer" />

--- a/contact.html
+++ b/contact.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
-  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
-  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
-  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
-  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" />
-  <link rel="manifest" href="site.webmanifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Contact POHL BANKRUPTCY, LLC for a free bankruptcy consultation in the Virgin Islands covering Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Contact | VI Bankruptcy" />
   <meta property="og:description" content="Contact POHL BANKRUPTCY, LLC for a free bankruptcy consultation in the Virgin Islands covering Chapters 7, 11, 12 &amp; 13." />

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
-  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
-  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
-  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
-  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" />
-  <link rel="manifest" href="site.webmanifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Legal disclaimer for viBankruptcy.com and POHL BANKRUPTCY, LLC regarding Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Disclaimer | VI Bankruptcy" />
   <meta property="og:description" content="Legal disclaimer for viBankruptcy.com and POHL BANKRUPTCY, LLC regarding Chapters 7, 11, 12 &amp; 13." />

--- a/faq.html
+++ b/faq.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
-  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
-  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
-  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
-  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" />
-  <link rel="manifest" href="site.webmanifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Answers to common bankruptcy questions for individuals and businesses in the Virgin Islands, including Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Bankruptcy FAQ | VI Bankruptcy" />
   <meta property="og:description" content="Answers to common bankruptcy questions for individuals and businesses in the Virgin Islands, including Chapters 7, 11, 12 &amp; 13." />

--- a/index.html
+++ b/index.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
-  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
-  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
-  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
-  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" />
-  <link rel="manifest" href="site.webmanifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Experienced Virgin Islands bankruptcy attorney offering personal and business debt relief under Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="VI Bankruptcy | Virgin Islands Debt Relief Attorney" />
   <meta property="og:description" content="Experienced Virgin Islands bankruptcy attorney offering personal and business debt relief under Chapters 7, 11, 12 &amp; 13." />

--- a/pay-online.html
+++ b/pay-online.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
-  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
-  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
-  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
-  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" />
-  <link rel="manifest" href="site.webmanifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Secure online payment portal for clients of POHL BANKRUPTCY, LLC handling Chapter 7, 11, 12 &amp; 13 matters." />
   <meta property="og:title" content="Pay Online | VI Bankruptcy" />
   <meta property="og:description" content="Secure online payment portal for clients of POHL BANKRUPTCY, LLC handling Chapter 7, 11, 12 &amp; 13 matters." />

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
-  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
-  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
-  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
-  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" />
-  <link rel="manifest" href="site.webmanifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Local guidance for Chapter 7 and Chapter 13 in the Virgin Islands. Stop lawsuits and garnishments, protect essentials, and rebuild credit with a clear plan. Free consultation." />
   <link rel="canonical" href="https://vibankruptcy.com/personal-bankruptcy.html" />
   <meta property="og:title" content="Virgin Islands Personal Bankruptcy Lawyer" />

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
-  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
-  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
-  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
-  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" />
-  <link rel="manifest" href="site.webmanifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Privacy practices of viBankruptcy.com and POHL BANKRUPTCY, LLC for Chapter 7, 11, 12 &amp; 13 services." />
   <meta property="og:title" content="Privacy Policy | VI Bankruptcy" />
   <meta property="og:description" content="Privacy practices of viBankruptcy.com and POHL BANKRUPTCY, LLC for Chapter 7, 11, 12 &amp; 13 services." />

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
-  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
-  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
-  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
-  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" />
-  <link rel="manifest" href="site.webmanifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Checklist of documents to prepare when filing bankruptcy with POHL BANKRUPTCY, LLC for Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Ready to File? Checklist | VI Bankruptcy" />
   <meta property="og:description" content="Checklist of documents to prepare when filing bankruptcy with POHL BANKRUPTCY, LLC for Chapters 7, 11, 12 &amp; 13." />

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -3,12 +3,12 @@
   "short_name": "VI Bankruptcy",
   "icons": [
     {
-      "src": "https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public",
+      "src": "/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public",
+      "src": "/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/testimonials.html
+++ b/testimonials.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public" />
-  <link rel="icon" type="image/png" sizes="32x32" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public" />
-  <link rel="icon" type="image/png" sizes="16x16" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public" />
-  <link rel="icon" type="image/png" sizes="192x192" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public" />
-  <link rel="icon" type="image/png" sizes="512x512" href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" />
-  <link rel="manifest" href="site.webmanifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Read testimonials from clients of POHL BANKRUPTCY, LLC in the Virgin Islands for Chapters 7, 11, 12 &amp; 13 cases." />
   <meta property="og:title" content="Testimonials | VI Bankruptcy" />
   <meta property="og:description" content="Read testimonials from clients of POHL BANKRUPTCY, LLC in the Virgin Islands for Chapters 7, 11, 12 &amp; 13 cases." />


### PR DESCRIPTION
## Summary
- reference all favicons from the website root instead of Cloudflare URLs
- update web manifest to use locally served icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a4f017634832183de386b08a54dc2