### PR TITLE
Add sitemap and robots files for search engines

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://vibankruptcy.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://vibankruptcy.com/index.html</loc></url>
+  <url><loc>https://vibankruptcy.com/about.html</loc></url>
+  <url><loc>https://vibankruptcy.com/business-bankruptcy.html</loc></url>
+  <url><loc>https://vibankruptcy.com/contact.html</loc></url>
+  <url><loc>https://vibankruptcy.com/disclaimer.html</loc></url>
+  <url><loc>https://vibankruptcy.com/faq.html</loc></url>
+  <url><loc>https://vibankruptcy.com/pay-online.html</loc></url>
+  <url><loc>https://vibankruptcy.com/personal-bankruptcy.html</loc></url>
+  <url><loc>https://vibankruptcy.com/privacy-policy.html</loc></url>
+  <url><loc>https://vibankruptcy.com/ready-to-file.html</loc></url>
+  <url><loc>https://vibankruptcy.com/testimonials.html</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- add XML sitemap listing public pages
- reference the sitemap from robots.txt for crawler discovery

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a62ad5b1c8321aa8e6224447bc26b