### PR TITLE
chore: update favicon assets

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,12 +3,11 @@
   <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
-  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <!-- Favicon and touch icon, place inside <head> -->
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
   <link rel="manifest" href="/site.webmanifest" />
   <meta
       name="description"
@@ -56,7 +55,7 @@
     <header class="site-header">
       <a href="index.html" class="logo-link">
         <img
-          src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public"
+  src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public"
           alt="VI Bankruptcy icon"
         />
         <span class="logo-text">Pohl Bankruptcy</span>

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -3,12 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
-  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <!-- Favicon and touch icon, place inside <head> -->
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Struggling with business debt in St. Thomas, St. John, or St. Croix? Learn how Chapter 11, Subchapter V, or Chapter 7 can protect operations, renegotiate leases, and resolve liabilities. Free consultation." />
   <link rel="canonical" href="https://vibankruptcy.com/business-bankruptcy.html" />
@@ -33,7 +32,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <a href="index.html" class="logo-link">
-      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
       <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>

--- a/contact.html
+++ b/contact.html
@@ -3,12 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
-  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <!-- Favicon and touch icon, place inside <head> -->
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Contact POHL BANKRUPTCY, LLC for a free bankruptcy consultation in the Virgin Islands covering Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Contact | VI Bankruptcy" />
@@ -36,7 +35,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -3,12 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
-  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <!-- Favicon and touch icon, place inside <head> -->
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Legal disclaimer for viBankruptcy.com and POHL BANKRUPTCY, LLC regarding Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Disclaimer | VI Bankruptcy" />
@@ -36,7 +35,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>

--- a/faq.html
+++ b/faq.html
@@ -3,12 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
-  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <!-- Favicon and touch icon, place inside <head> -->
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Answers to common bankruptcy questions for individuals and businesses in the Virgin Islands, including Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Bankruptcy FAQ | VI Bankruptcy" />
@@ -36,7 +35,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>

--- a/pay-online.html
+++ b/pay-online.html
@@ -3,12 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
-  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <!-- Favicon and touch icon, place inside <head> -->
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Secure online payment portal for clients of POHL BANKRUPTCY, LLC handling Chapter 7, 11, 12 &amp; 13 matters." />
   <meta property="og:title" content="Pay Online | VI Bankruptcy" />
@@ -36,7 +35,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -3,12 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
-  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <!-- Favicon and touch icon, place inside <head> -->
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Local guidance for Chapter 7 and Chapter 13 in the Virgin Islands. Stop lawsuits and garnishments, protect essentials, and rebuild credit with a clear plan. Free consultation." />
   <link rel="canonical" href="https://vibankruptcy.com/personal-bankruptcy.html" />
@@ -48,7 +47,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <a href="index.html" class="logo-link">
-      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
       <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -3,12 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
-  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <!-- Favicon and touch icon, place inside <head> -->
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Privacy practices of viBankruptcy.com and POHL BANKRUPTCY, LLC for Chapter 7, 11, 12 &amp; 13 services." />
   <meta property="og:title" content="Privacy Policy | VI Bankruptcy" />
@@ -36,7 +35,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -3,12 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
-  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <!-- Favicon and touch icon, place inside <head> -->
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Checklist of documents to prepare when filing bankruptcy with POHL BANKRUPTCY, LLC for Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Ready to File? Checklist | VI Bankruptcy" />
@@ -36,7 +35,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -3,14 +3,16 @@
   "short_name": "VI Bankruptcy",
   "icons": [
     {
-      "src": "/android-chrome-192x192.png",
+      "src": "https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any"
     },
     {
-      "src": "/android-chrome-512x512.png",
+      "src": "https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any"
     }
   ],
   "theme_color": "#132326",

--- a/testimonials.html
+++ b/testimonials.html
@@ -3,12 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
-  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <!-- Favicon and touch icon, place inside <head> -->
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Read testimonials from clients of POHL BANKRUPTCY, LLC in the Virgin Islands for Chapters 7, 11, 12 &amp; 13 cases." />
   <meta property="og:title" content="Testimonials | VI Bankruptcy" />
@@ -36,7 +35,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-        <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>


### PR DESCRIPTION
## Summary
- replace deprecated favicon references with Cloudflare-hosted icons across site pages
- update web manifest to reference the same Cloudflare image assets

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f87f84610832185a5519385c34287