### PR TITLE
Add favicon and structured data with HTML sitemap

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,12 +3,13 @@
   <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- Favicon and touch icon, place inside <head> -->
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
-  <link rel="manifest" href="/site.webmanifest" />
+    <!-- SNIPPET:FAVICONS:BEGIN -->
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <!-- SNIPPET:FAVICONS:END -->
+    <link rel="manifest" href="/site.webmanifest" />
   <meta
       name="description"
       content="Learn about Attorney Robert Pohl and how our firm helps Virgin Islanders find financial relief under Chapters 7, 11, 12 &amp; 13."
@@ -47,8 +48,18 @@
       href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap"
       rel="stylesheet"
     />
-  <link rel="stylesheet" href="styles.css" />
-  </head>
+    <link rel="stylesheet" href="styles.css" />
+    <!-- SNIPPET:BREADCRUMB:BEGIN -->
+    <script type="application/ld+json">{
+      "@context":"https://schema.org",
+      "@type":"BreadcrumbList",
+      "itemListElement":[
+        {"@type":"ListItem","position":1,"name":"Home","item":"https://vibankruptcy.com/"},
+        {"@type":"ListItem","position":2,"name":"About","item":"https://vibankruptcy.com/about.html"}
+      ]
+    }</script>
+    <!-- SNIPPET:BREADCRUMB:END -->
+    </head>
   <body>
     <div id="top"></div>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -851,5 +862,10 @@
         sections.forEach((section) => io.observe(section));
       })();
     </script>
+    <!-- SNIPPET:FOOTER-SITEMAP:BEGIN -->
+    <div style="text-align:center;font-size:0.9rem;margin:24px 0;">
+      <a href="/sitemap.html">Sitemap</a>
+    </div>
+    <!-- SNIPPET:FOOTER-SITEMAP:END -->
   </body>
 </html>

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -3,11 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- Favicon and touch icon, place inside <head> -->
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
+  <!-- SNIPPET:FAVICONS:BEGIN -->
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+  <!-- SNIPPET:FAVICONS:END -->
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Struggling with business debt in St. Thomas, St. John, or St. Croix? Learn how Chapter 11, Subchapter V, or Chapter 7 can protect operations, renegotiate leases, and resolve liabilities. Free consultation." />
   <link rel="canonical" href="https://vibankruptcy.com/business-bankruptcy.html" />
@@ -27,6 +28,16 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
+  <!-- SNIPPET:BREADCRUMB:BEGIN -->
+  <script type="application/ld+json">{
+    "@context":"https://schema.org",
+    "@type":"BreadcrumbList",
+    "itemListElement":[
+      {"@type":"ListItem","position":1,"name":"Home","item":"https://vibankruptcy.com/"},
+      {"@type":"ListItem","position":2,"name":"Business Bankruptcy","item":"https://vibankruptcy.com/business-bankruptcy.html"}
+    ]
+  }</script>
+  <!-- SNIPPET:BREADCRUMB:END -->
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
@@ -286,5 +297,10 @@
     <a href="tel:+13402033333">Call</a>
     <a href="contact.html">Free Consult</a>
   </div>
-  </body>
+<!-- SNIPPET:FOOTER-SITEMAP:BEGIN -->
+<div style="text-align:center;font-size:0.9rem;margin:24px 0;">
+  <a href="/sitemap.html">Sitemap</a>
+</div>
+<!-- SNIPPET:FOOTER-SITEMAP:END -->
+</body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- Favicon and touch icon, place inside <head> -->
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
-  <link rel="manifest" href="/site.webmanifest" />
+    <!-- SNIPPET:FAVICONS:BEGIN -->
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <!-- SNIPPET:FAVICONS:END -->
+    <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Contact POHL BANKRUPTCY, LLC for a free bankruptcy consultation in the Virgin Islands covering Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Contact | VI Bankruptcy" />
   <meta property="og:description" content="Contact POHL BANKRUPTCY, LLC for a free bankruptcy consultation in the Virgin Islands covering Chapters 7, 11, 12 &amp; 13." />
@@ -29,8 +30,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css" />
-</head>
+    <link rel="stylesheet" href="styles.css" />
+    <!-- SNIPPET:BREADCRUMB:BEGIN -->
+    <script type="application/ld+json">{
+      "@context":"https://schema.org",
+      "@type":"BreadcrumbList",
+      "itemListElement":[
+        {"@type":"ListItem","position":1,"name":"Home","item":"https://vibankruptcy.com/"},
+        {"@type":"ListItem","position":2,"name":"Contact","item":"https://vibankruptcy.com/contact.html"}
+      ]
+    }</script>
+    <!-- SNIPPET:BREADCRUMB:END -->
+  </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
@@ -184,6 +195,10 @@
     });
   });
 </script>
-
+<!-- SNIPPET:FOOTER-SITEMAP:BEGIN -->
+<div style="text-align:center;font-size:0.9rem;margin:24px 0;">
+  <a href="/sitemap.html">Sitemap</a>
+</div>
+<!-- SNIPPET:FOOTER-SITEMAP:END -->
 </body>
 </html>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- Favicon and touch icon, place inside <head> -->
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
-  <link rel="manifest" href="/site.webmanifest" />
+    <!-- SNIPPET:FAVICONS:BEGIN -->
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <!-- SNIPPET:FAVICONS:END -->
+    <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Legal disclaimer for viBankruptcy.com and POHL BANKRUPTCY, LLC regarding Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Disclaimer | VI Bankruptcy" />
   <meta property="og:description" content="Legal disclaimer for viBankruptcy.com and POHL BANKRUPTCY, LLC regarding Chapters 7, 11, 12 &amp; 13." />
@@ -29,8 +30,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css" />
-</head>
+    <link rel="stylesheet" href="styles.css" />
+    <!-- SNIPPET:BREADCRUMB:BEGIN -->
+    <script type="application/ld+json">{
+      "@context":"https://schema.org",
+      "@type":"BreadcrumbList",
+      "itemListElement":[
+        {"@type":"ListItem","position":1,"name":"Home","item":"https://vibankruptcy.com/"},
+        {"@type":"ListItem","position":2,"name":"Disclaimer","item":"https://vibankruptcy.com/disclaimer.html"}
+      ]
+    }</script>
+    <!-- SNIPPET:BREADCRUMB:END -->
+  </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
@@ -114,6 +125,10 @@
     });
   });
 </script>
-
+<!-- SNIPPET:FOOTER-SITEMAP:BEGIN -->
+<div style="text-align:center;font-size:0.9rem;margin:24px 0;">
+  <a href="/sitemap.html">Sitemap</a>
+</div>
+<!-- SNIPPET:FOOTER-SITEMAP:END -->
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- Favicon and touch icon, place inside <head> -->
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
-  <link rel="manifest" href="/site.webmanifest" />
+    <!-- SNIPPET:FAVICONS:BEGIN -->
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <!-- SNIPPET:FAVICONS:END -->
+    <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Answers to common bankruptcy questions for individuals and businesses in the Virgin Islands, including Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Bankruptcy FAQ | VI Bankruptcy" />
   <meta property="og:description" content="Answers to common bankruptcy questions for individuals and businesses in the Virgin Islands, including Chapters 7, 11, 12 &amp; 13." />
@@ -29,8 +30,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css" />
-</head>
+    <link rel="stylesheet" href="styles.css" />
+    <!-- SNIPPET:BREADCRUMB:BEGIN -->
+    <script type="application/ld+json">{
+      "@context":"https://schema.org",
+      "@type":"BreadcrumbList",
+      "itemListElement":[
+        {"@type":"ListItem","position":1,"name":"Home","item":"https://vibankruptcy.com/"},
+        {"@type":"ListItem","position":2,"name":"FAQ","item":"https://vibankruptcy.com/faq.html"}
+      ]
+    }</script>
+    <!-- SNIPPET:BREADCRUMB:END -->
+  </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
@@ -139,6 +150,10 @@
     });
   });
 </script>
-
+<!-- SNIPPET:FOOTER-SITEMAP:BEGIN -->
+<div style="text-align:center;font-size:0.9rem;margin:24px 0;">
+  <a href="/sitemap.html">Sitemap</a>
+</div>
+<!-- SNIPPET:FOOTER-SITEMAP:END -->
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
-  <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png" />
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <!-- SNIPPET:FAVICONS:BEGIN -->
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+  <!-- SNIPPET:FAVICONS:END -->
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Experienced Virgin Islands bankruptcy attorney offering personal and business debt relief under Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="VI Bankruptcy | Virgin Islands Debt Relief Attorney" />
@@ -236,7 +236,11 @@
       menuToggle.setAttribute('aria-expanded', 'false');
     });
   });
-</script>
-
-</body>
+  </script>
+  <!-- SNIPPET:FOOTER-SITEMAP:BEGIN -->
+  <div style="text-align:center;font-size:0.9rem;margin:24px 0;">
+    <a href="/sitemap.html">Sitemap</a>
+  </div>
+  <!-- SNIPPET:FOOTER-SITEMAP:END -->
+  </body>
 </html>

--- a/pay-online.html
+++ b/pay-online.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- Favicon and touch icon, place inside <head> -->
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
-  <link rel="manifest" href="/site.webmanifest" />
+    <!-- SNIPPET:FAVICONS:BEGIN -->
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <!-- SNIPPET:FAVICONS:END -->
+    <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Secure online payment portal for clients of POHL BANKRUPTCY, LLC handling Chapter 7, 11, 12 &amp; 13 matters." />
   <meta property="og:title" content="Pay Online | VI Bankruptcy" />
   <meta property="og:description" content="Secure online payment portal for clients of POHL BANKRUPTCY, LLC handling Chapter 7, 11, 12 &amp; 13 matters." />
@@ -29,8 +30,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css" />
-</head>
+    <link rel="stylesheet" href="styles.css" />
+    <!-- SNIPPET:BREADCRUMB:BEGIN -->
+    <script type="application/ld+json">{
+      "@context":"https://schema.org",
+      "@type":"BreadcrumbList",
+      "itemListElement":[
+        {"@type":"ListItem","position":1,"name":"Home","item":"https://vibankruptcy.com/"},
+        {"@type":"ListItem","position":2,"name":"Pay Online","item":"https://vibankruptcy.com/pay-online.html"}
+      ]
+    }</script>
+    <!-- SNIPPET:BREADCRUMB:END -->
+  </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
@@ -115,6 +126,10 @@
     });
   });
 </script>
-
+<!-- SNIPPET:FOOTER-SITEMAP:BEGIN -->
+<div style="text-align:center;font-size:0.9rem;margin:24px 0;">
+  <a href="/sitemap.html">Sitemap</a>
+</div>
+<!-- SNIPPET:FOOTER-SITEMAP:END -->
 </body>
 </html>

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- Favicon and touch icon, place inside <head> -->
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
-  <link rel="manifest" href="/site.webmanifest" />
+    <!-- SNIPPET:FAVICONS:BEGIN -->
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <!-- SNIPPET:FAVICONS:END -->
+    <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Local guidance for Chapter 7 and Chapter 13 in the Virgin Islands. Stop lawsuits and garnishments, protect essentials, and rebuild credit with a clear plan. Free consultation." />
   <link rel="canonical" href="https://vibankruptcy.com/personal-bankruptcy.html" />
   <meta property="og:title" content="Virgin Islands Personal Bankruptcy Lawyer" />
@@ -26,23 +27,33 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css" />
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "LegalService",
-    "name": "POHL Bankruptcy, LLC",
-    "areaServed": "U.S. Virgin Islands",
-    "url": "https://vibankruptcy.com/personal-bankruptcy.html",
-    "telephone": "+1-340-203-3333",
-    "address": [
-      {"@type": "PostalAddress", "streetAddress": "5316 Yacht Haven Grande, Suite N-104, Box 30", "addressLocality": "St. Thomas", "addressRegion": "VI", "postalCode": "00802"},
-      {"@type": "PostalAddress", "streetAddress": "5000 Estate Enighed, P.O. Box 343", "addressLocality": "St. John", "addressRegion": "VI", "postalCode": "00830"},
-      {"@type": "PostalAddress", "streetAddress": "6002 Diamond Ruby, Suite 3, PMB 633", "addressLocality": "Christiansted", "addressRegion": "VI", "postalCode": "00820"}
-    ]
-  }
-  </script>
-</head>
+    <link rel="stylesheet" href="styles.css" />
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "LegalService",
+      "name": "POHL Bankruptcy, LLC",
+      "areaServed": "U.S. Virgin Islands",
+      "url": "https://vibankruptcy.com/personal-bankruptcy.html",
+      "telephone": "+1-340-203-3333",
+      "address": [
+        {"@type": "PostalAddress", "streetAddress": "5316 Yacht Haven Grande, Suite N-104, Box 30", "addressLocality": "St. Thomas", "addressRegion": "VI", "postalCode": "00802"},
+        {"@type": "PostalAddress", "streetAddress": "5000 Estate Enighed, P.O. Box 343", "addressLocality": "St. John", "addressRegion": "VI", "postalCode": "00830"},
+        {"@type": "PostalAddress", "streetAddress": "6002 Diamond Ruby, Suite 3, PMB 633", "addressLocality": "Christiansted", "addressRegion": "VI", "postalCode": "00820"}
+      ]
+    }
+    </script>
+    <!-- SNIPPET:BREADCRUMB:BEGIN -->
+    <script type="application/ld+json">{
+      "@context":"https://schema.org",
+      "@type":"BreadcrumbList",
+      "itemListElement":[
+        {"@type":"ListItem","position":1,"name":"Home","item":"https://vibankruptcy.com/"},
+        {"@type":"ListItem","position":2,"name":"Personal Bankruptcy","item":"https://vibankruptcy.com/personal-bankruptcy.html"}
+      ]
+    }</script>
+    <!-- SNIPPET:BREADCRUMB:END -->
+  </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
@@ -263,5 +274,10 @@
     <a href="tel:+13402033333">Call</a>
     <a href="contact.html">Free Consult</a>
   </div>
+  <!-- SNIPPET:FOOTER-SITEMAP:BEGIN -->
+  <div style="text-align:center;font-size:0.9rem;margin:24px 0;">
+    <a href="/sitemap.html">Sitemap</a>
+  </div>
+  <!-- SNIPPET:FOOTER-SITEMAP:END -->
   </body>
 </html>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- Favicon and touch icon, place inside <head> -->
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
-  <link rel="manifest" href="/site.webmanifest" />
+    <!-- SNIPPET:FAVICONS:BEGIN -->
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <!-- SNIPPET:FAVICONS:END -->
+    <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Privacy practices of viBankruptcy.com and POHL BANKRUPTCY, LLC for Chapter 7, 11, 12 &amp; 13 services." />
   <meta property="og:title" content="Privacy Policy | VI Bankruptcy" />
   <meta property="og:description" content="Privacy practices of viBankruptcy.com and POHL BANKRUPTCY, LLC for Chapter 7, 11, 12 &amp; 13 services." />
@@ -29,8 +30,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css" />
-</head>
+    <link rel="stylesheet" href="styles.css" />
+    <!-- SNIPPET:BREADCRUMB:BEGIN -->
+    <script type="application/ld+json">{
+      "@context":"https://schema.org",
+      "@type":"BreadcrumbList",
+      "itemListElement":[
+        {"@type":"ListItem","position":1,"name":"Home","item":"https://vibankruptcy.com/"},
+        {"@type":"ListItem","position":2,"name":"Privacy Policy","item":"https://vibankruptcy.com/privacy-policy.html"}
+      ]
+    }</script>
+    <!-- SNIPPET:BREADCRUMB:END -->
+  </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
@@ -114,6 +125,10 @@
     });
   });
 </script>
-
+<!-- SNIPPET:FOOTER-SITEMAP:BEGIN -->
+<div style="text-align:center;font-size:0.9rem;margin:24px 0;">
+  <a href="/sitemap.html">Sitemap</a>
+</div>
+<!-- SNIPPET:FOOTER-SITEMAP:END -->
 </body>
 </html>

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- Favicon and touch icon, place inside <head> -->
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
-  <link rel="manifest" href="/site.webmanifest" />
+    <!-- SNIPPET:FAVICONS:BEGIN -->
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <!-- SNIPPET:FAVICONS:END -->
+    <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Checklist of documents to prepare when filing bankruptcy with POHL BANKRUPTCY, LLC for Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Ready to File? Checklist | VI Bankruptcy" />
   <meta property="og:description" content="Checklist of documents to prepare when filing bankruptcy with POHL BANKRUPTCY, LLC for Chapters 7, 11, 12 &amp; 13." />
@@ -29,8 +30,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css" />
-</head>
+    <link rel="stylesheet" href="styles.css" />
+    <!-- SNIPPET:BREADCRUMB:BEGIN -->
+    <script type="application/ld+json">{
+      "@context":"https://schema.org",
+      "@type":"BreadcrumbList",
+      "itemListElement":[
+        {"@type":"ListItem","position":1,"name":"Home","item":"https://vibankruptcy.com/"},
+        {"@type":"ListItem","position":2,"name":"Ready to File","item":"https://vibankruptcy.com/ready-to-file.html"}
+      ]
+    }</script>
+    <!-- SNIPPET:BREADCRUMB:END -->
+  </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
@@ -137,6 +148,10 @@
     });
   });
 </script>
-
+<!-- SNIPPET:FOOTER-SITEMAP:BEGIN -->
+<div style="text-align:center;font-size:0.9rem;margin:24px 0;">
+  <a href="/sitemap.html">Sitemap</a>
+</div>
+<!-- SNIPPET:FOOTER-SITEMAP:END -->
 </body>
 </html>

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -2,18 +2,8 @@
   "name": "Pohl Bankruptcy",
   "short_name": "VI Bankruptcy",
   "icons": [
-    {
-      "src": "https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "any"
-    }
+    {"src":"https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public","sizes":"192x192","type":"image/png","purpose":"any"},
+    {"src":"https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public","sizes":"512x512","type":"image/png","purpose":"any"}
   ],
   "theme_color": "#132326",
   "background_color": "#132326",

--- a/sitemap.html
+++ b/sitemap.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- SNIPPET:FAVICONS:BEGIN -->
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+  <!-- SNIPPET:FAVICONS:END -->
+  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <title>HTML Sitemap</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main>
+    <h1>HTML Sitemap</h1>
+    <ul>
+      <li><a href="/">Home</a></li>
+      <li><a href="/about.html">About</a></li>
+      <li><a href="/business-bankruptcy.html">Business Bankruptcy</a></li>
+      <li><a href="/contact.html">Contact</a></li>
+      <li><a href="/disclaimer.html">Disclaimer</a></li>
+      <li><a href="/faq.html">FAQ</a></li>
+      <li><a href="/pay-online.html">Pay Online</a></li>
+      <li><a href="/personal-bankruptcy.html">Personal Bankruptcy</a></li>
+      <li><a href="/privacy-policy.html">Privacy Policy</a></li>
+      <li><a href="/ready-to-file.html">Ready to File</a></li>
+      <li><a href="/testimonials.html">Testimonials</a></li>
+    </ul>
+  </main>
+  <!-- SNIPPET:FOOTER-SITEMAP:BEGIN -->
+  <div style="text-align:center;font-size:0.9rem;margin:24px 0;">
+    <a href="/sitemap.html">Sitemap</a>
+  </div>
+  <!-- SNIPPET:FOOTER-SITEMAP:END -->
+</body>
+</html>

--- a/testimonials.html
+++ b/testimonials.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- Favicon and touch icon, place inside <head> -->
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png"/>
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180"/>
-  <link rel="manifest" href="/site.webmanifest" />
+    <!-- SNIPPET:FAVICONS:BEGIN -->
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <!-- SNIPPET:FAVICONS:END -->
+    <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Read testimonials from clients of POHL BANKRUPTCY, LLC in the Virgin Islands for Chapters 7, 11, 12 &amp; 13 cases." />
   <meta property="og:title" content="Testimonials | VI Bankruptcy" />
   <meta property="og:description" content="Read testimonials from clients of POHL BANKRUPTCY, LLC in the Virgin Islands for Chapters 7, 11, 12 &amp; 13 cases." />
@@ -29,8 +30,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="styles.css" />
-</head>
+    <link rel="stylesheet" href="styles.css" />
+    <!-- SNIPPET:BREADCRUMB:BEGIN -->
+    <script type="application/ld+json">{
+      "@context":"https://schema.org",
+      "@type":"BreadcrumbList",
+      "itemListElement":[
+        {"@type":"ListItem","position":1,"name":"Home","item":"https://vibankruptcy.com/"},
+        {"@type":"ListItem","position":2,"name":"Testimonials","item":"https://vibankruptcy.com/testimonials.html"}
+      ]
+    }</script>
+    <!-- SNIPPET:BREADCRUMB:END -->
+  </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
@@ -135,6 +146,10 @@
     });
   });
 </script>
-
+<!-- SNIPPET:FOOTER-SITEMAP:BEGIN -->
+<div style="text-align:center;font-size:0.9rem;margin:24px 0;">
+  <a href="/sitemap.html">Sitemap</a>
+</div>
+<!-- SNIPPET:FOOTER-SITEMAP:END -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace legacy icon tags with Cloudflare-hosted favicon block and ensure preconnect for images
- Add BreadcrumbList JSON-LD to internal pages and link to new HTML sitemap footer
- Update web manifest icons and create an HTML sitemap page listing key site routes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f917a1cc88321a03c878a696502d6