### PR TITLE
Rewrite Cloudflare image URLs and preconnect domain

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
     <!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta property="og:title" content="About | VI Bankruptcy" />
@@ -17,13 +17,13 @@
     />
   <meta
       property="og:image"
-      content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public"
+      content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public"
     />
   <meta property="og:url" content="https://vibankruptcy.com/about.html" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta
       name="twitter:image"
-      content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public"
+      content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public"
     />
   <link rel="canonical" href="https://vibankruptcy.com/about.html" />
   <meta
@@ -33,7 +33,7 @@
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="VI Bankruptcy" />
   <meta property="og:locale" content="en_US" />
-  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <link rel="preconnect" href="https://vibankruptcy.com" crossorigin>
   <meta name="theme-color" content="#132326" />
   <title>About | VI Bankruptcy</title>
   <meta name="description" content="Learn about VI Bankruptcy, personal and business bankruptcy services across the U.S. Virgin Islands, and our commitment to client service." />
@@ -63,7 +63,7 @@
     <header class="site-header">
       <a href="index.html" class="logo-link">
         <img
-  src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public"
+  src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public"
           alt="VI Bankruptcy icon"
         />
         <span class="logo-text">Pohl Bankruptcy</span>
@@ -117,7 +117,7 @@
         <div class="about-toolbar__inner">
           <img
             class="toolbar-logo"
-            src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8dd67803-ace6-499b-f07e-3aa217afcf00/public"
+            src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/8dd67803-ace6-499b-f07e-3aa217afcf00/public"
             alt=""
             aria-hidden="true"
             width="96"
@@ -156,7 +156,7 @@
         <div class="about-wrapper">
           <img
             class="about-photo"
-            src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/1ab4fdc6-aa8f-4845-1760-5d6bdbd1e300/public"
+            src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/1ab4fdc6-aa8f-4845-1760-5d6bdbd1e300/public"
             alt="Pencil drawing of attorney Robert A. Pohl"
             width="1024"
             height="1024"
@@ -263,7 +263,7 @@
             <!-- Decorative bird watermark -->
             <img
               class="contact-card__bird"
-              src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/8dd67803-ace6-499b-f07e-3aa217afcf00/public"
+              src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/8dd67803-ace6-499b-f07e-3aa217afcf00/public"
               alt=""
               aria-hidden="true"
               width="1366"

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- SNIPPET:FAVICONS:BEGIN -->
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
   <!-- SNIPPET:FAVICONS:END -->
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Struggling with business debt in St. Thomas, St. John, or St. Croix? Learn how Chapter 11, Subchapter V, or Chapter 7 can protect operations, renegotiate leases, and resolve liabilities. Free consultation." />
@@ -16,12 +16,12 @@
   <meta property="og:description" content="Guidance for Chapter 11, Subchapter V, and Chapter 7. Keep operating while restructuring or wind down cleanly." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://vibankruptcy.com/business-bankruptcy.html" />
-  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
+  <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:site_name" content="VI Bankruptcy" />
   <meta property="og:locale" content="en_US" />
-  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <link rel="preconnect" href="https://vibankruptcy.com" crossorigin>
   <meta name="theme-color" content="#132326" />
   <title>Virgin Islands Business Bankruptcy Lawyer | Chapter 11 and Subchapter V</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -43,7 +43,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <a href="index.html" class="logo-link">
-  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
       <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>
@@ -167,7 +167,7 @@
   <section class="bg-gray">
     <h2 class="section-title">Attorney Profile</h2>
     <div class="attorney-card">
-      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public" alt="Robert Pohl, Bankruptcy Attorney" loading="lazy" decoding="async" width="1366" height="768" />
+      <img src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public" alt="Robert Pohl, Bankruptcy Attorney" loading="lazy" decoding="async" width="1366" height="768" />
       <div class="attorney-card__content">
         <h3>Work directly with Robert A. Pohl</h3>
         <ul class="styled-list">
@@ -256,7 +256,7 @@
     "name": "POHL Bankruptcy, LLC",
     "areaServed": "U.S. Virgin Islands",
     "url": "https://vibankruptcy.com/business-bankruptcy.html",
-    "image": "https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public",
+    "image": "https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public",
     "address": [{
       "@type": "PostalAddress",
       "streetAddress": "5316 Yacht Haven Grande, Suite N-104, Box 30",

--- a/contact.html
+++ b/contact.html
@@ -4,25 +4,25 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
     <!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Contact POHL BANKRUPTCY, LLC for a free bankruptcy consultation in the Virgin Islands covering Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Contact | VI Bankruptcy" />
   <meta property="og:description" content="Contact POHL BANKRUPTCY, LLC for a free bankruptcy consultation in the Virgin Islands covering Chapters 7, 11, 12 &amp; 13." />
-  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
+  <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/contact.html" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
+  <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/contact.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="VI Bankruptcy" />
   <meta property="og:locale" content="en_US" />
-  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <link rel="preconnect" href="https://vibankruptcy.com" crossorigin>
   <meta name="theme-color" content="#132326" />
   <title>Contact | VI Bankruptcy</title>
 
@@ -46,7 +46,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -4,25 +4,25 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
     <!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Legal disclaimer for viBankruptcy.com and POHL BANKRUPTCY, LLC regarding Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Disclaimer | VI Bankruptcy" />
   <meta property="og:description" content="Legal disclaimer for viBankruptcy.com and POHL BANKRUPTCY, LLC regarding Chapters 7, 11, 12 &amp; 13." />
-  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
+  <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/disclaimer.html" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
+  <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/disclaimer.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="VI Bankruptcy" />
   <meta property="og:locale" content="en_US" />
-  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <link rel="preconnect" href="https://vibankruptcy.com" crossorigin>
   <meta name="theme-color" content="#132326" />
   <title>Disclaimer | VI Bankruptcy</title>
 
@@ -46,7 +46,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>

--- a/faq.html
+++ b/faq.html
@@ -4,25 +4,25 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
     <!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Answers to common bankruptcy questions for individuals and businesses in the Virgin Islands, including Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Bankruptcy FAQ | VI Bankruptcy" />
   <meta property="og:description" content="Answers to common bankruptcy questions for individuals and businesses in the Virgin Islands, including Chapters 7, 11, 12 &amp; 13." />
-  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
+  <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/faq.html" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
+  <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/faq.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="VI Bankruptcy" />
   <meta property="og:locale" content="en_US" />
-  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <link rel="preconnect" href="https://vibankruptcy.com" crossorigin>
   <meta name="theme-color" content="#132326" />
   <title>Bankruptcy FAQ | VI Bankruptcy</title>
 
@@ -46,7 +46,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>

--- a/index.html
+++ b/index.html
@@ -4,25 +4,25 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- SNIPPET:FAVICONS:BEGIN -->
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
   <!-- SNIPPET:FAVICONS:END -->
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Experienced Virgin Islands bankruptcy attorney offering personal and business debt relief under Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="VI Bankruptcy | Virgin Islands Debt Relief Attorney" />
   <meta property="og:description" content="Experienced Virgin Islands bankruptcy attorney offering personal and business debt relief under Chapters 7, 11, 12 &amp; 13." />
-  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
+  <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
+  <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="VI Bankruptcy" />
   <meta property="og:locale" content="en_US" />
-  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <link rel="preconnect" href="https://vibankruptcy.com" crossorigin>
   <meta name="theme-color" content="#132326" />
   <title>VI Bankruptcy | Virgin Islands Debt Relief Attorney</title>
 
@@ -52,8 +52,8 @@
   "@id":"https://vibankruptcy.com/#organization",
   "name":"POHL BANKRUPTCY, LLC",
   "url":"https://vibankruptcy.com/",
-  "logo":{"@type":"ImageObject","url":"https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public"},
-  "image":{"@type":"ImageObject","url":"https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public"},
+  "logo":{"@type":"ImageObject","url":"https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public"},
+  "image":{"@type":"ImageObject","url":"https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public"},
   "telephone":"+1-340-203-3333",
   "email":"robert@pohlbankruptcy.com"
 }</script>
@@ -68,7 +68,7 @@
   "url":"https://vibankruptcy.com/",
   "telephone":"+1-340-203-3333",
   "areaServed":["St. Thomas","St. Croix","St. John","U.S. Virgin Islands"],
-  "image":"https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public",
+  "image":"https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public",
   "parentOrganization":{"@id":"https://vibankruptcy.com/#organization"},
   "address":[
     {"@type":"PostalAddress","streetAddress":"5316 Yacht Haven Grande, Suite N-104 Box 30","addressLocality":"St. Thomas","addressRegion":"VI","postalCode":"00802","addressCountry":"US"},
@@ -81,7 +81,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <a href="index.html" class="logo-link">
-      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+      <img src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
       <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>

--- a/pay-online.html
+++ b/pay-online.html
@@ -4,25 +4,25 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
     <!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Secure online payment portal for clients of POHL BANKRUPTCY, LLC handling Chapter 7, 11, 12 &amp; 13 matters." />
   <meta property="og:title" content="Pay Online | VI Bankruptcy" />
   <meta property="og:description" content="Secure online payment portal for clients of POHL BANKRUPTCY, LLC handling Chapter 7, 11, 12 &amp; 13 matters." />
-  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
+  <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/pay-online.html" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
+  <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/pay-online.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="VI Bankruptcy" />
   <meta property="og:locale" content="en_US" />
-  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <link rel="preconnect" href="https://vibankruptcy.com" crossorigin>
   <meta name="theme-color" content="#132326" />
   <title>Pay Online | VI Bankruptcy</title>
 
@@ -46,7 +46,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
     <!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Local guidance for Chapter 7 and Chapter 13 in the Virgin Islands. Stop lawsuits and garnishments, protect essentials, and rebuild credit with a clear plan. Free consultation." />
@@ -16,12 +16,12 @@
   <meta property="og:description" content="Understand Chapter 7, Chapter 13, and other options. Get a fresh start with a plan that fits your life." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://vibankruptcy.com/personal-bankruptcy.html" />
-  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
+  <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:site_name" content="VI Bankruptcy" />
   <meta property="og:locale" content="en_US" />
-  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <link rel="preconnect" href="https://vibankruptcy.com" crossorigin>
   <meta name="theme-color" content="#132326" />
   <title>Virgin Islands Personal Bankruptcy Lawyer | Chapter 7 and Chapter 13</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -58,7 +58,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
     <a href="index.html" class="logo-link">
-  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
       <span class="logo-text">Pohl Bankruptcy</span>
     </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>
@@ -174,7 +174,7 @@
   <section class="bg-gray">
     <h2 class="section-title">Attorney Profile</h2>
     <div class="attorney-card">
-      <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public" alt="Robert Pohl, Bankruptcy Attorney" loading="lazy" decoding="async" width="1366" height="768" />
+      <img src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public" alt="Robert Pohl, Bankruptcy Attorney" loading="lazy" decoding="async" width="1366" height="768" />
       <div class="attorney-card__content">
         <h3>Work directly with Robert A. Pohl</h3>
         <ul class="styled-list">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -4,25 +4,25 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
     <!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Privacy practices of viBankruptcy.com and POHL BANKRUPTCY, LLC for Chapter 7, 11, 12 &amp; 13 services." />
   <meta property="og:title" content="Privacy Policy | VI Bankruptcy" />
   <meta property="og:description" content="Privacy practices of viBankruptcy.com and POHL BANKRUPTCY, LLC for Chapter 7, 11, 12 &amp; 13 services." />
-  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
+  <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/privacy-policy.html" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
+  <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/privacy-policy.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="VI Bankruptcy" />
   <meta property="og:locale" content="en_US" />
-  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <link rel="preconnect" href="https://vibankruptcy.com" crossorigin>
   <meta name="theme-color" content="#132326" />
   <title>Privacy Policy | VI Bankruptcy</title>
 
@@ -46,7 +46,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -4,25 +4,25 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
     <!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Checklist of documents to prepare when filing bankruptcy with POHL BANKRUPTCY, LLC for Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Ready to File? Checklist | VI Bankruptcy" />
   <meta property="og:description" content="Checklist of documents to prepare when filing bankruptcy with POHL BANKRUPTCY, LLC for Chapters 7, 11, 12 &amp; 13." />
-  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
+  <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/ready-to-file.html" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
+  <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/ready-to-file.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="VI Bankruptcy" />
   <meta property="og:locale" content="en_US" />
-  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <link rel="preconnect" href="https://vibankruptcy.com" crossorigin>
   <meta name="theme-color" content="#132326" />
   <title>Ready to File? Checklist | VI Bankruptcy</title>
 
@@ -46,7 +46,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -2,8 +2,8 @@
   "name": "Pohl Bankruptcy",
   "short_name": "VI Bankruptcy",
   "icons": [
-    {"src":"https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public","sizes":"192x192","type":"image/png","purpose":"any"},
-    {"src":"https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public","sizes":"512x512","type":"image/png","purpose":"any"}
+    {"src":"https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public","sizes":"192x192","type":"image/png","purpose":"any"},
+    {"src":"https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public","sizes":"512x512","type":"image/png","purpose":"any"}
   ],
   "theme_color": "#132326",
   "background_color": "#132326",

--- a/sitemap.html
+++ b/sitemap.html
@@ -4,13 +4,13 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- SNIPPET:FAVICONS:BEGIN -->
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-  <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
   <!-- SNIPPET:FAVICONS:END -->
   <link rel="manifest" href="/site.webmanifest" />
-  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <link rel="preconnect" href="https://vibankruptcy.com" crossorigin>
   <title>HTML Sitemap</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/testimonials.html
+++ b/testimonials.html
@@ -4,25 +4,25 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
     <!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Read testimonials from clients of POHL BANKRUPTCY, LLC in the Virgin Islands for Chapters 7, 11, 12 &amp; 13 cases." />
   <meta property="og:title" content="Testimonials | VI Bankruptcy" />
   <meta property="og:description" content="Read testimonials from clients of POHL BANKRUPTCY, LLC in the Virgin Islands for Chapters 7, 11, 12 &amp; 13 cases." />
-  <meta property="og:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
+  <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta property="og:url" content="https://vibankruptcy.com/testimonials.html" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
+  <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="canonical" href="https://vibankruptcy.com/testimonials.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="VI Bankruptcy" />
   <meta property="og:locale" content="en_US" />
-  <link rel="preconnect" href="https://imagedelivery.net" crossorigin />
+  <link rel="preconnect" href="https://vibankruptcy.com" crossorigin>
   <meta name="theme-color" content="#132326" />
   <title>Testimonials | VI Bankruptcy</title>
 
@@ -46,7 +46,7 @@
   <a class="skip-link" href="#main">Skip to content</a>
   <header class="site-header">
       <a href="index.html" class="logo-link">
-  <img src="https://imagedelivery.net/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
+  <img src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
     <button id="menu-toggle" class="btn" aria-expanded="false">☰ Menu</button>


### PR DESCRIPTION
## Summary
- rewrite Cloudflare Image URLs to use vibankruptcy.com CDN endpoint
- switch preconnect links from imagedelivery.net to vibankruptcy.com

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0171bcdfc83218b91366ded0157c1