### PR TITLE
Replace favicon snippet and update social images

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,12 +3,12 @@
   <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
-    <!-- SNIPPET:FAVICONS:END -->
+<!-- SNIPPET:FAVICONS:BEGIN -->
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+<!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta property="og:title" content="About | VI Bankruptcy" />
   <meta

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- SNIPPET:FAVICONS:BEGIN -->
-  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
-  <!-- SNIPPET:FAVICONS:END -->
+<!-- SNIPPET:FAVICONS:BEGIN -->
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+<!-- SNIPPET:FAVICONS:END -->
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Struggling with business debt in St. Thomas, St. John, or St. Croix? Learn how Chapter 11, Subchapter V, or Chapter 7 can protect operations, renegotiate leases, and resolve liabilities. Free consultation." />
   <link rel="canonical" href="https://vibankruptcy.com/business-bankruptcy.html" />
@@ -18,6 +18,7 @@
   <meta property="og:url" content="https://vibankruptcy.com/business-bankruptcy.html" />
   <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:site_name" content="VI Bankruptcy" />
   <meta property="og:locale" content="en_US" />

--- a/contact.html
+++ b/contact.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
-    <!-- SNIPPET:FAVICONS:END -->
+<!-- SNIPPET:FAVICONS:BEGIN -->
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+<!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Contact POHL BANKRUPTCY, LLC for a free bankruptcy consultation in the Virgin Islands covering Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Contact | VI Bankruptcy" />

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
-    <!-- SNIPPET:FAVICONS:END -->
+<!-- SNIPPET:FAVICONS:BEGIN -->
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+<!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Legal disclaimer for viBankruptcy.com and POHL BANKRUPTCY, LLC regarding Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Disclaimer | VI Bankruptcy" />

--- a/faq.html
+++ b/faq.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
-    <!-- SNIPPET:FAVICONS:END -->
+<!-- SNIPPET:FAVICONS:BEGIN -->
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+<!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Answers to common bankruptcy questions for individuals and businesses in the Virgin Islands, including Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Bankruptcy FAQ | VI Bankruptcy" />

--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- SNIPPET:FAVICONS:BEGIN -->
-  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
-  <!-- SNIPPET:FAVICONS:END -->
+<!-- SNIPPET:FAVICONS:BEGIN -->
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+<!-- SNIPPET:FAVICONS:END -->
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Experienced Virgin Islands bankruptcy attorney offering personal and business debt relief under Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="VI Bankruptcy | Virgin Islands Debt Relief Attorney" />

--- a/pay-online.html
+++ b/pay-online.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
-    <!-- SNIPPET:FAVICONS:END -->
+<!-- SNIPPET:FAVICONS:BEGIN -->
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+<!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Secure online payment portal for clients of POHL BANKRUPTCY, LLC handling Chapter 7, 11, 12 &amp; 13 matters." />
   <meta property="og:title" content="Pay Online | VI Bankruptcy" />

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
-    <!-- SNIPPET:FAVICONS:END -->
+<!-- SNIPPET:FAVICONS:BEGIN -->
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+<!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Local guidance for Chapter 7 and Chapter 13 in the Virgin Islands. Stop lawsuits and garnishments, protect essentials, and rebuild credit with a clear plan. Free consultation." />
   <link rel="canonical" href="https://vibankruptcy.com/personal-bankruptcy.html" />
@@ -18,6 +18,7 @@
   <meta property="og:url" content="https://vibankruptcy.com/personal-bankruptcy.html" />
   <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta property="og:site_name" content="VI Bankruptcy" />
   <meta property="og:locale" content="en_US" />

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
-    <!-- SNIPPET:FAVICONS:END -->
+<!-- SNIPPET:FAVICONS:BEGIN -->
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+<!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Privacy practices of viBankruptcy.com and POHL BANKRUPTCY, LLC for Chapter 7, 11, 12 &amp; 13 services." />
   <meta property="og:title" content="Privacy Policy | VI Bankruptcy" />

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
-    <!-- SNIPPET:FAVICONS:END -->
+<!-- SNIPPET:FAVICONS:BEGIN -->
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+<!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Checklist of documents to prepare when filing bankruptcy with POHL BANKRUPTCY, LLC for Chapters 7, 11, 12 &amp; 13." />
   <meta property="og:title" content="Ready to File? Checklist | VI Bankruptcy" />

--- a/sitemap.html
+++ b/sitemap.html
@@ -3,13 +3,16 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- SNIPPET:FAVICONS:BEGIN -->
-  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-  <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
-  <!-- SNIPPET:FAVICONS:END -->
+<!-- SNIPPET:FAVICONS:BEGIN -->
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+<!-- SNIPPET:FAVICONS:END -->
   <link rel="manifest" href="/site.webmanifest" />
+  <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public" />
   <link rel="preconnect" href="https://vibankruptcy.com" crossorigin>
   <title>HTML Sitemap</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/testimonials.html
+++ b/testimonials.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- SNIPPET:FAVICONS:BEGIN -->
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
-    <link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
-    <!-- SNIPPET:FAVICONS:END -->
+<!-- SNIPPET:FAVICONS:BEGIN -->
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="48x48" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="192x192" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="icon" sizes="512x512" type="image/png">
+<link href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public" rel="apple-touch-icon" sizes="180x180">
+<!-- SNIPPET:FAVICONS:END -->
     <link rel="manifest" href="/site.webmanifest" />
   <meta name="description" content="Read testimonials from clients of POHL BANKRUPTCY, LLC in the Virgin Islands for Chapters 7, 11, 12 &amp; 13 cases." />
   <meta property="og:title" content="Testimonials | VI Bankruptcy" />


### PR DESCRIPTION
## Summary
- replace favicon snippet across site pages with vibankruptcy.com icons
- standardize Open Graph and Twitter metadata with vibankruptcy.com image host

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a018c5a96083218ab706a3300b4af8