### PR TITLE
Add security headers and update robots directives

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,40 @@
+/*
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: interest-cohort=()
+  X-Frame-Options: SAMEORIGIN
+
+/*.css
+  Cache-Control: public, max-age=31536000, immutable
+  Content-Type: text/css; charset=utf-8
+
+/*.js
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.woff2
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.png
+  Cache-Control: public, max-age=31536000, immutable
+  Access-Control-Allow-Origin: *
+
+/*.jpg
+  Cache-Control: public, max-age=31536000, immutable
+  Access-Control-Allow-Origin: *
+
+/*.jpeg
+  Cache-Control: public, max-age=31536000, immutable
+  Access-Control-Allow-Origin: *
+
+/*.webp
+  Cache-Control: public, max-age=31536000, immutable
+  Access-Control-Allow-Origin: *
+
+/*.svg
+  Cache-Control: public, max-age=31536000, immutable
+  Access-Control-Allow-Origin: *
+
+/*.ico
+  Cache-Control: public, max-age=31536000, immutable
+  Access-Control-Allow-Origin: *
+

--- a/robots.txt
+++ b/robots.txt
@@ -1,6 +1,6 @@
 User-agent: *
-Allow: /
+Allow: /cdn-cgi/imagedelivery/
+Disallow: /cdn-cgi/
 Disallow: /private/
 Crawl-delay: 10
-
-Sitemap: https://vibankruptcy.com/sitemap.xml
+Sitemap: https://vibankruptcy.com/sitemap.xml.


### PR DESCRIPTION
## Summary
- replace robots.txt with updated directives, allowing CDN image delivery and disallowing other CDN paths
- add a Netlify-style `_headers` file configuring security and caching headers for common asset types

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a01d3f93f883218eba953692605fea