### PR TITLE
Update Cloudflare headers for vibankruptcy.com

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,40 +1,71 @@
 /*
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Permissions-Policy: interest-cohort=()
   X-Frame-Options: SAMEORIGIN
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
+
+/*.html
+  Cache-Control: max-age=0, must-revalidate
+  X-Robots-Tag: max-image-preview:large
+
+/
+  Cache-Control: max-age=0, must-revalidate
+  X-Robots-Tag: max-image-preview:large
 
 /*.css
   Cache-Control: public, max-age=31536000, immutable
-  Content-Type: text/css; charset=utf-8
 
 /*.js
   Cache-Control: public, max-age=31536000, immutable
 
 /*.woff2
   Cache-Control: public, max-age=31536000, immutable
+  Access-Control-Allow-Origin: *
 
-/*.png
+/*.woff
   Cache-Control: public, max-age=31536000, immutable
   Access-Control-Allow-Origin: *
 
-/*.jpg
-  Cache-Control: public, max-age=31536000, immutable
-  Access-Control-Allow-Origin: *
-
-/*.jpeg
-  Cache-Control: public, max-age=31536000, immutable
-  Access-Control-Allow-Origin: *
-
-/*.webp
+/*.ttf
   Cache-Control: public, max-age=31536000, immutable
   Access-Control-Allow-Origin: *
 
 /*.svg
   Cache-Control: public, max-age=31536000, immutable
-  Access-Control-Allow-Origin: *
 
-/*.ico
+/*.png
   Cache-Control: public, max-age=31536000, immutable
+
+/*.jpg
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.jpeg
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.webp
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.avif
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.gif
+  Cache-Control: public, max-age=31536000, immutable
+
+/site.webmanifest
+  Cache-Control: public, max-age=86400
+  Content-Type: application/manifest+json; charset=utf-8
   Access-Control-Allow-Origin: *
 
+/favicon.ico
+  Cache-Control: public, max-age=31536000, immutable
+
+/
+  Link: </styles.css>; rel=preload; as=style
+/*.html
+  Link: </styles.css>; rel=preload; as=style
+
+https://:project.pages.dev/*
+  X-Robots-Tag: noindex
+
+https://:version.:project.pages.dev/*
+  X-Robots-Tag: noindex


### PR DESCRIPTION
## Summary
- expand Cloudflare Pages `_headers` to include security headers, caching policies, and preload link for styles.css

## Testing
- `rg -n "preconnect" *.html`
- `rg -n "imagedelivery" *.html`

------
https://chatgpt.com/codex/tasks/task_e_68a02856c31483218891d8858de8d52f