### PR TITLE
Normalize icons and headers

### DIFF
--- a/_headers
+++ b/_headers
@@ -32,6 +32,7 @@
 
 /*.svg
   Cache-Control: public, max-age=31536000, immutable
+  Content-Type: image/svg+xml
 
 /*.png
   Cache-Control: public, max-age=31536000, immutable
@@ -58,6 +59,7 @@
 
 /favicon.ico
   Cache-Control: public, max-age=31536000, immutable
+  Content-Type: image/x-icon
 
 /
   Link: </styles.css>; rel=preload; as=style

--- a/about.html
+++ b/about.html
@@ -40,17 +40,17 @@
       ]
     }</script>
     <!-- SNIPPET:BREADCRUMB:END -->
-      <!-- Icons and social, normalized -->
-  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
-  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
-  <link rel="apple-touch-icon" sizes="180x180" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public">
-  <link rel="manifest" href="/site.webmanifest">
-  <!-- Optional: keep .ico as fallback if it exists at the root -->
-  <link rel="icon" href="/favicon.ico" sizes="any">
-
   <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public">
+  <!-- Icons, normalized for Google and browsers -->
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" type="image/png" sizes="96x96" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/1629645b-6142-4af9-92ff-46c3c53f1f00/public">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
+  <link rel="apple-touch-icon" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/17d1a359-4bfb-4fd5-8a99-9d01bd758400/public">
+  <link rel="apple-touch-icon-precomposed" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/66006b0e-1b5c-44b3-b53a-123cececa300/public">
+  <link rel="manifest" href="/site.webmanifest">
 </head>
   <body>
     <div id="top"></div>
@@ -59,8 +59,7 @@
       <a href="index.html" class="logo-link">
         <img
   src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b0e1c617-ab4f-4cec-fcd3-069434816600/public"
-          alt="VI Bankruptcy icon"
-        />
+          alt="VI Bankruptcy icon" />
         <span class="logo-text">Pohl Bankruptcy</span>
       </a>
       <button id="menu-toggle" class="btn" aria-expanded="false">Menu</button>
@@ -151,7 +150,7 @@
         <div class="about-wrapper">
           <img
             class="about-photo"
-            src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/9fbd2df4-ebb4-4047-4397-7f2d03f5e900/public"
+            src="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/eb7145e4-7f8e-412e-f84f-f7d8eeb63c00/public"
             alt="Portrait of attorney Robert Pohl"
             width="1024"
             height="1024"

--- a/business-bankruptcy.html
+++ b/business-bankruptcy.html
@@ -29,17 +29,17 @@
     ]
   }</script>
   <!-- SNIPPET:BREADCRUMB:END -->
-  <!-- Icons and social, normalized -->
-  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
-  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
-  <link rel="apple-touch-icon" sizes="180x180" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public">
-  <link rel="manifest" href="/site.webmanifest">
-  <!-- Optional: keep .ico as fallback if it exists at the root -->
-  <link rel="icon" href="/favicon.ico" sizes="any">
-
   <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public">
+  <!-- Icons, normalized for Google and browsers -->
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" type="image/png" sizes="96x96" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/1629645b-6142-4af9-92ff-46c3c53f1f00/public">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
+  <link rel="apple-touch-icon" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/17d1a359-4bfb-4fd5-8a99-9d01bd758400/public">
+  <link rel="apple-touch-icon-precomposed" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/66006b0e-1b5c-44b3-b53a-123cececa300/public">
+  <link rel="manifest" href="/site.webmanifest">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/contact.html
+++ b/contact.html
@@ -31,17 +31,17 @@
       ]
     }</script>
     <!-- SNIPPET:BREADCRUMB:END -->
-    <!-- Icons and social, normalized -->
-  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
-  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
-  <link rel="apple-touch-icon" sizes="180x180" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public">
-  <link rel="manifest" href="/site.webmanifest">
-  <!-- Optional: keep .ico as fallback if it exists at the root -->
-  <link rel="icon" href="/favicon.ico" sizes="any">
-
   <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public">
+  <!-- Icons, normalized for Google and browsers -->
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" type="image/png" sizes="96x96" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/1629645b-6142-4af9-92ff-46c3c53f1f00/public">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
+  <link rel="apple-touch-icon" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/17d1a359-4bfb-4fd5-8a99-9d01bd758400/public">
+  <link rel="apple-touch-icon-precomposed" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/66006b0e-1b5c-44b3-b53a-123cececa300/public">
+  <link rel="manifest" href="/site.webmanifest">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -31,17 +31,17 @@
       ]
     }</script>
     <!-- SNIPPET:BREADCRUMB:END -->
-    <!-- Icons and social, normalized -->
-  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
-  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
-  <link rel="apple-touch-icon" sizes="180x180" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public">
-  <link rel="manifest" href="/site.webmanifest">
-  <!-- Optional: keep .ico as fallback if it exists at the root -->
-  <link rel="icon" href="/favicon.ico" sizes="any">
-
   <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public">
+  <!-- Icons, normalized for Google and browsers -->
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" type="image/png" sizes="96x96" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/1629645b-6142-4af9-92ff-46c3c53f1f00/public">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
+  <link rel="apple-touch-icon" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/17d1a359-4bfb-4fd5-8a99-9d01bd758400/public">
+  <link rel="apple-touch-icon-precomposed" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/66006b0e-1b5c-44b3-b53a-123cececa300/public">
+  <link rel="manifest" href="/site.webmanifest">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/faq.html
+++ b/faq.html
@@ -31,17 +31,17 @@
       ]
     }</script>
     <!-- SNIPPET:BREADCRUMB:END -->
-    <!-- Icons and social, normalized -->
-  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
-  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
-  <link rel="apple-touch-icon" sizes="180x180" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public">
-  <link rel="manifest" href="/site.webmanifest">
-  <!-- Optional: keep .ico as fallback if it exists at the root -->
-  <link rel="icon" href="/favicon.ico" sizes="any">
-
   <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public">
+  <!-- Icons, normalized for Google and browsers -->
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" type="image/png" sizes="96x96" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/1629645b-6142-4af9-92ff-46c3c53f1f00/public">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
+  <link rel="apple-touch-icon" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/17d1a359-4bfb-4fd5-8a99-9d01bd758400/public">
+  <link rel="apple-touch-icon-precomposed" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/66006b0e-1b5c-44b3-b53a-123cececa300/public">
+  <link rel="manifest" href="/site.webmanifest">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/index.html
+++ b/index.html
@@ -66,17 +66,17 @@
   ]
 }</script>
   <!-- SNIPPET:SCHEMA:LEGAL:END -->
-  <!-- Icons and social, normalized -->
-  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
-  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
-  <link rel="apple-touch-icon" sizes="180x180" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public">
-  <link rel="manifest" href="/site.webmanifest">
-  <!-- Optional: keep .ico as fallback if it exists at the root -->
-  <link rel="icon" href="/favicon.ico" sizes="any">
-
   <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public">
+  <!-- Icons, normalized for Google and browsers -->
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" type="image/png" sizes="96x96" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/1629645b-6142-4af9-92ff-46c3c53f1f00/public">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
+  <link rel="apple-touch-icon" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/17d1a359-4bfb-4fd5-8a99-9d01bd758400/public">
+  <link rel="apple-touch-icon-precomposed" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/66006b0e-1b5c-44b3-b53a-123cececa300/public">
+  <link rel="manifest" href="/site.webmanifest">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/pay-online.html
+++ b/pay-online.html
@@ -31,17 +31,17 @@
       ]
     }</script>
     <!-- SNIPPET:BREADCRUMB:END -->
-    <!-- Icons and social, normalized -->
-  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
-  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
-  <link rel="apple-touch-icon" sizes="180x180" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public">
-  <link rel="manifest" href="/site.webmanifest">
-  <!-- Optional: keep .ico as fallback if it exists at the root -->
-  <link rel="icon" href="/favicon.ico" sizes="any">
-
   <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public">
+  <!-- Icons, normalized for Google and browsers -->
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" type="image/png" sizes="96x96" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/1629645b-6142-4af9-92ff-46c3c53f1f00/public">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
+  <link rel="apple-touch-icon" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/17d1a359-4bfb-4fd5-8a99-9d01bd758400/public">
+  <link rel="apple-touch-icon-precomposed" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/66006b0e-1b5c-44b3-b53a-123cececa300/public">
+  <link rel="manifest" href="/site.webmanifest">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/personal-bankruptcy.html
+++ b/personal-bankruptcy.html
@@ -44,17 +44,17 @@
       ]
     }</script>
     <!-- SNIPPET:BREADCRUMB:END -->
-    <!-- Icons and social, normalized -->
-  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
-  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
-  <link rel="apple-touch-icon" sizes="180x180" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public">
-  <link rel="manifest" href="/site.webmanifest">
-  <!-- Optional: keep .ico as fallback if it exists at the root -->
-  <link rel="icon" href="/favicon.ico" sizes="any">
-
   <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public">
+  <!-- Icons, normalized for Google and browsers -->
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" type="image/png" sizes="96x96" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/1629645b-6142-4af9-92ff-46c3c53f1f00/public">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
+  <link rel="apple-touch-icon" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/17d1a359-4bfb-4fd5-8a99-9d01bd758400/public">
+  <link rel="apple-touch-icon-precomposed" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/66006b0e-1b5c-44b3-b53a-123cececa300/public">
+  <link rel="manifest" href="/site.webmanifest">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -31,17 +31,17 @@
       ]
     }</script>
     <!-- SNIPPET:BREADCRUMB:END -->
-    <!-- Icons and social, normalized -->
-  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
-  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
-  <link rel="apple-touch-icon" sizes="180x180" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public">
-  <link rel="manifest" href="/site.webmanifest">
-  <!-- Optional: keep .ico as fallback if it exists at the root -->
-  <link rel="icon" href="/favicon.ico" sizes="any">
-
   <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public">
+  <!-- Icons, normalized for Google and browsers -->
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" type="image/png" sizes="96x96" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/1629645b-6142-4af9-92ff-46c3c53f1f00/public">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
+  <link rel="apple-touch-icon" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/17d1a359-4bfb-4fd5-8a99-9d01bd758400/public">
+  <link rel="apple-touch-icon-precomposed" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/66006b0e-1b5c-44b3-b53a-123cececa300/public">
+  <link rel="manifest" href="/site.webmanifest">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/ready-to-file.html
+++ b/ready-to-file.html
@@ -31,17 +31,17 @@
       ]
     }</script>
     <!-- SNIPPET:BREADCRUMB:END -->
-    <!-- Icons and social, normalized -->
-  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
-  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
-  <link rel="apple-touch-icon" sizes="180x180" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public">
-  <link rel="manifest" href="/site.webmanifest">
-  <!-- Optional: keep .ico as fallback if it exists at the root -->
-  <link rel="icon" href="/favicon.ico" sizes="any">
-
   <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public">
+  <!-- Icons, normalized for Google and browsers -->
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" type="image/png" sizes="96x96" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/1629645b-6142-4af9-92ff-46c3c53f1f00/public">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
+  <link rel="apple-touch-icon" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/17d1a359-4bfb-4fd5-8a99-9d01bd758400/public">
+  <link rel="apple-touch-icon-precomposed" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/66006b0e-1b5c-44b3-b53a-123cececa300/public">
+  <link rel="manifest" href="/site.webmanifest">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -3,13 +3,13 @@
   "short_name": "VI Bankruptcy",
   "icons": [
     {
-      "src": "https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/6b6812b8-983a-4d5e-cd89-6f551ac50600/public",
+      "src": "https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/61569e62-3498-4d3a-2104-2a1da3fad100/public",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/b4c57f74-c8ac-48fb-34e3-c59a3101e800/public",
+      "src": "https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/6a591978-6834-45f2-7eb9-d710f6ed7900/public",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"

--- a/sitemap.html
+++ b/sitemap.html
@@ -9,17 +9,17 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
-  <!-- Icons and social, normalized -->
-  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
-  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
-  <link rel="apple-touch-icon" sizes="180x180" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public">
-  <link rel="manifest" href="/site.webmanifest">
-  <!-- Optional: keep .ico as fallback if it exists at the root -->
-  <link rel="icon" href="/favicon.ico" sizes="any">
-
   <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public">
+  <!-- Icons, normalized for Google and browsers -->
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" type="image/png" sizes="96x96" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/1629645b-6142-4af9-92ff-46c3c53f1f00/public">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
+  <link rel="apple-touch-icon" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/17d1a359-4bfb-4fd5-8a99-9d01bd758400/public">
+  <link rel="apple-touch-icon-precomposed" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/66006b0e-1b5c-44b3-b53a-123cececa300/public">
+  <link rel="manifest" href="/site.webmanifest">
 </head>
 <body>
   <main>

--- a/testimonials.html
+++ b/testimonials.html
@@ -31,17 +31,17 @@
       ]
     }</script>
     <!-- SNIPPET:BREADCRUMB:END -->
-    <!-- Icons and social, normalized -->
-  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
-  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
-  <link rel="apple-touch-icon" sizes="180x180" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/8ce3064c-4032-4e1e-9f6d-0ad8c6d93d00/public">
-  <link rel="manifest" href="/site.webmanifest">
-  <!-- Optional: keep .ico as fallback if it exists at the root -->
-  <link rel="icon" href="/favicon.ico" sizes="any">
-
   <meta property="og:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/992c7107-c08c-4063-70b0-7d8090b0d200/public">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/c6c2ae93-3a0f-448b-4031-83f8886ca400/public">
+  <!-- Icons, normalized for Google and browsers -->
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" type="image/png" sizes="96x96" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/1629645b-6142-4af9-92ff-46c3c53f1f00/public">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/d9ed5aa7-7ae5-416e-5549-6bf415506d00/public">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/0742c3df-2900-400a-dfde-5914d3ac9400/public">
+  <link rel="apple-touch-icon" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/17d1a359-4bfb-4fd5-8a99-9d01bd758400/public">
+  <link rel="apple-touch-icon-precomposed" href="https://vibankruptcy.com/cdn-cgi/imagedelivery/MqlML99ManDWvfuYMb9PmQ/66006b0e-1b5c-44b3-b53a-123cececa300/public">
+  <link rel="manifest" href="/site.webmanifest">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>


### PR DESCRIPTION
## Summary
- Normalize favicon and manifest links across site
- Refresh about page portrait and manifest icons
- Set cache and content-type headers for SVG and favicon

## Testing
- `npx -y htmlhint about.html business-bankruptcy.html contact.html disclaimer.html faq.html index.html pay-online.html personal-bankruptcy.html privacy-policy.html ready-to-file.html sitemap.html testimonials.html`
- `npx -y htmlhint about.html`

------
https://chatgpt.com/codex/tasks/task_e_68a035b949548321b364a6eaa99b7455