### PR TITLE
Normalize headers for robots.txt and sitemap

### DIFF
--- a/_headers
+++ b/_headers
@@ -61,6 +61,20 @@
   Cache-Control: public, max-age=31536000, immutable
   Content-Type: image/x-icon
 
+/robots.txt
+  ! Cache-Control
+  Cache-Control: public, max-age=3600
+  ! Content-Type
+  Content-Type: text/plain; charset=utf-8
+  X-Content-Type-Options: nosniff
+
+/sitemap.xml
+  ! Cache-Control
+  Cache-Control: public, max-age=3600
+  ! Content-Type
+  Content-Type: application/xml; charset=utf-8
+  X-Content-Type-Options: nosniff
+
 /
   Link: </styles.css>; rel=preload; as=style
 /*.html


### PR DESCRIPTION
## Summary
- Add detached Cache-Control and Content-Type headers for `robots.txt` and `sitemap.xml` to ensure consistent 200 responses with correct content types and caching

## Testing
- `ls _redirects` (file absent; no conflicting redirects)


------
https://chatgpt.com/codex/tasks/task_e_68a25d1c6d488321a208319ab4e8927a